### PR TITLE
CAS validation operation added

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,6 +2,18 @@
 
 Following operations are supported by the CAS commandline interface.
 
+## Validate CAS file
+
+Checks if the provided CAS data files comply with the specified CAS schema. In case of invalid files, the system logs the issues and throws an exception.
+
+```commandline
+cas validate --schema bican --data path/to/file
+```
+
+**Command-line Arguments:**
+- `--schema`    : One of 'base', 'bican' or 'cap'. Identifies the CAS schema to validate data against.
+- `--data`   : Path to the data file (or folder) to validate. If given path is a folder, validates all json files inside.
+
 ## Flatten onto AnnData
 
 Processes and integrates information from a JSON file and an AnnData (Annotated Data) file,  creating a new AnnData object that incorporates the metadata. The resulting AnnData object is then saved to a new file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,7 @@ anndata==0.10.3
 dataclasses_json
 pandas
 ruamel.yaml
-jsonschema
+jsonschema==4.4.0
+ordered-set==4.1.0
+deepmerge==1.1.0
+# TODO: cell-annotation-schema

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ ruamel.yaml
 jsonschema==4.4.0
 ordered-set==4.1.0
 deepmerge==1.1.0
-# TODO: cell-annotation-schema
+cell-annotation-schema

--- a/src/cas/__main__.py
+++ b/src/cas/__main__.py
@@ -169,9 +169,9 @@ def create_schema_validation_operation_parser(subparsers):
     """
     parser_validate = subparsers.add_parser("validate",
                                          description="The CAS file structure validator",
-                                         help="Test if given CAS has a valid structure.")
+                                         help="Test if given CAS is compatible with the CAS schema.")
 
-    parser_validate.add_argument("--schema", required=True, help="One of 'base', 'bican' or 'cap'")
+    parser_validate.add_argument("--schema", required=True, help="Schema name: one of 'base', 'bican' or 'cap'")
     parser_validate.add_argument("--data", required=True, help="Path to the data file (or folder) to validate", type=pathlib.Path)
 
 

--- a/src/cas/validate.py
+++ b/src/cas/validate.py
@@ -10,8 +10,8 @@ from cas_schema import schema_validator, schemas
 warnings.filterwarnings("always")
 
 SCHEMA_FILE_MAPPING = {"base": "general_schema.json",
-                       "bican": "CAP_schema.json",
-                       "cap": "BICAN_schema.json"}
+                       "cap": "CAP_schema.json",
+                       "bican": "BICAN_schema.json"}
 
 
 def validate(schema_name: str, data_path: str):
@@ -37,4 +37,4 @@ def validate(schema_name: str, data_path: str):
     if not result:
         raise Exception("Validation Failed")
 
-
+    return True

--- a/src/cas/validate.py
+++ b/src/cas/validate.py
@@ -1,0 +1,40 @@
+import os
+import json
+import warnings
+
+from importlib import resources
+
+from cas_schema import schema_validator, schemas
+
+
+warnings.filterwarnings("always")
+
+SCHEMA_FILE_MAPPING = {"base": "general_schema.json",
+                       "bican": "CAP_schema.json",
+                       "cap": "BICAN_schema.json"}
+
+
+def validate(schema_name: str, data_path: str):
+    """
+    Validates all instances in data_path against the given schema.
+    Assumes all *.json files in the test_dir should validate against the schema.
+    Logs all validation errors and throws an exception if any of the test files is invalid.
+    Parameters:
+        schema_name: One of 'base', 'bican' or 'cap'. Identifies the CAS schema to validate data against.
+        data_path: Path to the data file (or folder) to validate
+    """
+    schema_name = str(schema_name).strip().lower()
+    if schema_name not in SCHEMA_FILE_MAPPING:
+        raise Exception("Schema name should be one of 'base', 'bican' or 'cap'")
+    if not os.path.exists(data_path):
+        raise Exception("Please provide a valid 'data_path': {}".format(data_path))
+
+    schema_file = (resources.files(schemas) / SCHEMA_FILE_MAPPING[schema_name])
+    with schema_file.open("rt") as f:
+        schema = json.loads(f.read())
+
+    result = schema_validator.validate(schema, SCHEMA_FILE_MAPPING[schema_name], data_path)
+    if not result:
+        raise Exception("Validation Failed")
+
+

--- a/src/test/test_data/validation/BICAN_schema_specific_examples/Silletti_annotation_transfer.json
+++ b/src/test/test_data/validation/BICAN_schema_specific_examples/Silletti_annotation_transfer.json
@@ -1,0 +1,22 @@
+{
+  "author_name": "Kimberley Siletti",
+  "labelsets": [{
+    "name": "Subtype",
+    "rank": 0
+     }
+  ],
+  "annotations": [
+    {
+      "labelset": "Subtype",
+      "cell_label": "INT-VIP",
+      "transferred_annotations": [
+        {
+          "transferred_cell_label": "Vip",
+          "source taxonomy": "http://bican.org/taxonomy/CS1908210",
+          "source_node_accession": "CS1908210085",
+          "comment": "We performed PCA (50 components) on our full dataset, trained a random forest classifier (scikit-learn, class_weight='balanced', max_depth=50) on the MTG labels, and then predicted labels for all cells. We labeled each cluster with the mode of its constituent cells if two conditions were met: more than 0.8 of predicted labels matched the mode, and the mean probability of these predictions was greater than 0.8."
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/test_data/validation/BICAN_schema_specific_examples/Yao_ABC_labelset.json
+++ b/src/test/test_data/validation/BICAN_schema_specific_examples/Yao_ABC_labelset.json
@@ -1,0 +1,46 @@
+{
+  "author_name": "Zizhen Yao",
+  "orcid": "0000-0002-9361-5607",
+  "labelsets": [
+    {
+      "name": "Cluster",
+      "description": "The coarse level of cell type definition in the mouse whole brain taxonomy. All cells within a supertype belong to the same subclass. Subclass groups together related supertypes.",
+      "rank": 0
+    },
+    {
+      "name": "SubClass",
+      "rank": 1,
+      "description": "The coarse level of cell type definition in the mouse whole brain taxonomy. All cells within a supertype belong to the same subclass. Subclass groups together related supertypes."
+    },
+    {
+      "name": "NT",
+      "description": "neurotransmitter, inferred from gene expression. Value must be one of 'Glu, GABA, Gly, Ser, Dop'"
+    }
+  ],
+  "annotations": [
+    {
+      "labelset": "Cluster",
+      "cell_label": "1_MSN",
+      "accession": "CCN20230822_1",
+      "parent_cell_set_accessions": [
+        "CCN20230822_204",
+        "CCN20230822_304"
+      ]
+    },
+    {
+      "labelset": "Subclass",
+      "cell_label": "D1 matrix",
+      "accession": "CCN20230822_204",
+      "cell_ontology_term": "matrix D1 medium spiny neuron",
+      "cell_ontology_term_id": "CL:4030043"
+    },
+    {
+      "labelset": "NT",
+      "cell_label": "GABA",
+      "accession": "CCN20230822_304",
+      "marker_evidence": [
+        "SLC6-A2"
+      ]
+    }
+  ]
+}

--- a/src/test/validator_test.py
+++ b/src/test/validator_test.py
@@ -1,0 +1,30 @@
+import unittest
+import os
+import warnings
+
+from cas.validate import validate
+
+warnings.filterwarnings("always")
+
+TEST_JSON = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                         "./test_data/validation/BICAN_schema_specific_examples/Silletti_annotation_transfer.json")
+TEST_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                           "./test_data/validation/BICAN_schema_specific_examples")
+
+
+class ValidatorTests(unittest.TestCase):
+
+    def test_file_validation(self):
+        try:
+            validate("bican", TEST_JSON)
+            self.fail("A validation error should occur here")
+        except Exception as e:
+            self.assertEqual("Validation Failed", e.args[0])
+
+    def test_folder_validation(self):
+        try:
+            validate("bican", TEST_FOLDER)
+            self.fail("A validation error should occur here")
+        except Exception as e:
+            self.assertEqual("Validation Failed", e.args[0])
+

--- a/src/test/validator_test.py
+++ b/src/test/validator_test.py
@@ -16,15 +16,19 @@ class ValidatorTests(unittest.TestCase):
 
     def test_file_validation(self):
         try:
-            validate("bican", TEST_JSON)
+            validate("cap", TEST_JSON)
             self.fail("A validation error should occur here")
         except Exception as e:
             self.assertEqual("Validation Failed", e.args[0])
 
+        self.assertTrue(validate("bican", TEST_JSON))
+
     def test_folder_validation(self):
         try:
-            validate("bican", TEST_FOLDER)
+            validate("cap", TEST_FOLDER)
             self.fail("A validation error should occur here")
         except Exception as e:
             self.assertEqual("Validation Failed", e.args[0])
+
+        self.assertTrue(validate("bican", TEST_FOLDER))
 


### PR DESCRIPTION
Uses `[cell-annotation-schema](https://github.com/cellannotation/cell-annotation-schema)` as `pypi` package and checks if a provided CAS files comply with a specified (one of `base`, `bican` or `cap`) CAS schema.

`Validate` operation is a wrapper for `cell-annotation-schema` `validate` function. System reads the related schema directly from the pypi package and runs `cas_schema.schema_validator.validate` operation.