### PR TITLE
CAS flattening operation bug

### DIFF
--- a/src/cas/__main__.py
+++ b/src/cas/__main__.py
@@ -12,8 +12,10 @@ warnings.filterwarnings("always")
 
 
 def main():
-    parser = argparse.ArgumentParser(prog="cas", description='Cell Type Annotation Tools cli interface.')
-    subparsers = parser.add_subparsers(help='Available ctat actions', dest='action')
+    parser = argparse.ArgumentParser(
+        prog="cas", description="Cell Type Annotation Tools cli interface."
+    )
+    subparsers = parser.add_subparsers(help="Available ctat actions", dest="action")
 
     create_merge_operation_parser(subparsers)
     create_flatten_operation_parser(subparsers)
@@ -72,13 +74,17 @@ def create_merge_operation_parser(subparsers):
     cd src
     python -m cas merge --json path/to/CAS_schema.json --anndata path/to/input_anndata.h5ad --validate --output path/to/output.h5ad
     """
-    parser_merge = subparsers.add_parser("merge",
-                                         description="The CAS and AnnData merge parser",
-                                         help="Test if CAS can be merged to the AnnData and merges if possible.")
+    parser_merge = subparsers.add_parser(
+        "merge",
+        description="The CAS and AnnData merge parser",
+        help="Test if CAS can be merged to the AnnData and merges if possible.",
+    )
     parser_merge.add_argument(
         "--json", required=True, help="Path to the CAS JSON schema file."
     )
-    parser_merge.add_argument("--anndata", required=True, help="Path to the AnnData file.")
+    parser_merge.add_argument(
+        "--anndata", required=True, help="Path to the AnnData file."
+    )
     # TODO find a better argument name and Help message.
     parser_merge.add_argument(
         "-v",
@@ -108,13 +114,17 @@ def create_flatten_operation_parser(subparsers):
     cd src
     python -m cas flatten --json path/to/json_file.json --anndata path/to/anndata_file.h5ad --output path/to/output_file.h5ad
     """
-    parser_flatten = subparsers.add_parser("flatten",
-                                         description="Flattens all content of CAS annotations to an AnnData file.",
-                                         help="Flattens all content of CAS annotations to obs key:value pairs. "
-                                              "Flattens all other content to key_value pairs in uns.")
+    parser_flatten = subparsers.add_parser(
+        "flatten",
+        description="Flattens all content of CAS annotations to an AnnData file.",
+        help="Flattens all content of CAS annotations to obs key:value pairs. "
+        "Flattens all other content to key_value pairs in uns.",
+    )
 
     parser_flatten.add_argument("--json", required=True, help="Input JSON file path")
-    parser_flatten.add_argument("--anndata", required=True, help="Input AnnData file path")
+    parser_flatten.add_argument(
+        "--anndata", required=True, help="Input AnnData file path"
+    )
     parser_flatten.add_argument(
         "-v",
         "--validate",
@@ -142,12 +152,16 @@ def create_populate_cells_operation_parser(subparsers):
     cd src
     python -m cas populate_cells --json path/to/json_file.json --anndata path/to/anndata_file.h5ad --labelsets Cluster,Supercluster
     """
-    parser_populate = subparsers.add_parser("populate_cells",
-                                         description="The CAS cell IDs population operation.",
-                                         help="Checks for alignment between obs key:value pairs in AnnData file and labelset:cell_label pairs in CAS for some specified list of labelsets. If they are aligned, updates cell_ids in CAS.")
+    parser_populate = subparsers.add_parser(
+        "populate_cells",
+        description="The CAS cell IDs population operation.",
+        help="Checks for alignment between obs key:value pairs in AnnData file and labelset:cell_label pairs in CAS for some specified list of labelsets. If they are aligned, updates cell_ids in CAS.",
+    )
 
     parser_populate.add_argument("--json", required=True, help="Input JSON file path")
-    parser_populate.add_argument("--anndata", required=True, help="Input AnnData file path")
+    parser_populate.add_argument(
+        "--anndata", required=True, help="Input AnnData file path"
+    )
     parser_populate.add_argument(
         "--labelsets",
         help="List of labelsets to update with IDs from AnnData",
@@ -168,12 +182,21 @@ def create_schema_validation_operation_parser(subparsers):
     cd src
     python -m cas validate --schema bican --data path/to/file
     """
-    parser_validate = subparsers.add_parser("validate",
-                                         description="The CAS file structure validator",
-                                         help="Test if given CAS is compatible with the CAS schema.")
+    parser_validate = subparsers.add_parser(
+        "validate",
+        description="The CAS file structure validator",
+        help="Test if given CAS is compatible with the CAS schema.",
+    )
 
-    parser_validate.add_argument("--schema", required=True, help="Schema name: one of 'base', 'bican' or 'cap'")
-    parser_validate.add_argument("--data", required=True, help="Path to the data file (or folder) to validate", type=pathlib.Path)
+    parser_validate.add_argument(
+        "--schema", required=True, help="Schema name: one of 'base', 'bican' or 'cap'"
+    )
+    parser_validate.add_argument(
+        "--data",
+        required=True,
+        help="Path to the data file (or folder) to validate",
+        type=pathlib.Path,
+    )
 
 
 if __name__ == "__main__":

--- a/src/cas/accession/hash_accession_manager.py
+++ b/src/cas/accession/hash_accession_manager.py
@@ -5,7 +5,6 @@ from cas.accession.base_accession_manager import BaseAccessionManager
 
 
 class HashAccessionManager(BaseAccessionManager):
-
     def __init__(self, accession_prefix=None, digest_size=5):
         """
         Initializer.
@@ -17,7 +16,9 @@ class HashAccessionManager(BaseAccessionManager):
         self.digest_size = digest_size
         self.accession_ids = list()
 
-    def generate_accession_id(self, id_recommendation: str = None, cell_ids: List = None) -> str:
+    def generate_accession_id(
+        self, id_recommendation: str = None, cell_ids: List = None
+    ) -> str:
         """
         Generates a Blake2b hashing algorithm based hash for the given cell IDs.
         Params:
@@ -28,7 +29,9 @@ class HashAccessionManager(BaseAccessionManager):
         if not cell_ids:
             raise Exception("Cell IDs list is empty.")
 
-        blake_hasher = hashlib.blake2b(str.encode(" ".join(sorted(cell_ids))), digest_size=self.digest_size)
+        blake_hasher = hashlib.blake2b(
+            str.encode(" ".join(sorted(cell_ids))), digest_size=self.digest_size
+        )
         accession_id = blake_hasher.hexdigest()
 
         if accession_id in self.accession_ids:
@@ -37,4 +40,3 @@ class HashAccessionManager(BaseAccessionManager):
         else:
             self.accession_ids.append(accession_id)
         return accession_id
-

--- a/src/cas/accession/incremental_accession_manager.py
+++ b/src/cas/accession/incremental_accession_manager.py
@@ -27,8 +27,11 @@ class IncrementalAccessionManager(BaseAccessionManager):
         if id_recommendation:
             id_recommendation = id_recommendation.replace(self.accession_prefix, "")
 
-        if (id_recommendation and id_recommendation not in self.accession_ids and
-                int(id_recommendation) > self.last_accession_id):
+        if (
+            id_recommendation
+            and id_recommendation not in self.accession_ids
+            and int(id_recommendation) > self.last_accession_id
+        ):
             accession_id = id_recommendation
             self.last_accession_id = int(id_recommendation)
         else:

--- a/src/cas/anndata_conversion.py
+++ b/src/cas/anndata_conversion.py
@@ -95,12 +95,12 @@ def check_labelsets(cas_json, input_anndata, matching_obs_keys, validate):
                 .to_dict()
             )
             for cell_label, cell_list in anndata_labelset_cell_ids.items():
-                if cell_list == derived_cell_ids.get(str(ann["cell_set_accession"]), set()):
+                if cell_list == derived_cell_ids.get(
+                    str(ann["cell_set_accession"]), set()
+                ):
                     handle_matching_labelset(ann, cell_label, input_anndata, validate)
                 elif cell_label == ann[CELL_LABEL]:
-                    handle_non_matching_labelset(
-                        ann, cell_label, cell_list, input_anndata, validate, derived_cell_ids
-                    )
+                    handle_non_matching_labelset(ann, validate, derived_cell_ids)
 
 
 def get_cas_annotations(input_json):
@@ -132,7 +132,7 @@ def handle_matching_labelset(ann, cell_label, input_anndata, validate):
         ].map({cell_label: ann[CELL_LABEL]})
 
 
-def handle_non_matching_labelset(ann, cell_label, cell_list, input_anndata, validate, derived_cell_ids):
+def handle_non_matching_labelset(ann, input_anndata, validate, derived_cell_ids):
     print(
         f"{ann[CELL_LABEL]} cell ids from CAS do not match with the cell ids from anndata. "
         "Please update your CAS json."
@@ -197,7 +197,9 @@ def get_derived_cell_ids(cas):
 
     labelsets = sorted(cas[LABELSETS], key=lambda x: int(x["rank"]))
     for labelset in labelsets:
-        ls_annotations = [ann for ann in cas[ANNOTATIONS] if ann["labelset"] == labelset["name"]]
+        ls_annotations = [
+            ann for ann in cas[ANNOTATIONS] if ann["labelset"] == labelset["name"]
+        ]
 
         for ann in ls_annotations:
             if "parent_cell_set_accession" in ann:
@@ -205,7 +207,10 @@ def get_derived_cell_ids(cas):
                 if CELL_IDS in ann and ann[CELL_IDS]:
                     cell_ids = set(ann[CELL_IDS])
                     derived_cell_ids[ann["cell_set_accession"]] = cell_ids
-                elif "cell_set_accession" in ann and ann["cell_set_accession"] in derived_cell_ids:
+                elif (
+                    "cell_set_accession" in ann
+                    and ann["cell_set_accession"] in derived_cell_ids
+                ):
                     cell_ids = derived_cell_ids[str(ann["cell_set_accession"])]
 
                 if ann["parent_cell_set_accession"] in derived_cell_ids:

--- a/src/cas/file_utils.py
+++ b/src/cas/file_utils.py
@@ -66,7 +66,9 @@ def read_cas_from_anndata(anndata_path: str) -> CellTypeAnnotation:
         raise Exception("Given Anndata file doesn't have a 'cas' object in it's uns.")
 
 
-def write_json_file(cas: CellTypeAnnotation, out_file: str, print_undefined: bool = False):
+def write_json_file(
+    cas: CellTypeAnnotation, out_file: str, print_undefined: bool = False
+):
     """
     Writes cell type annotation object to a json file.
     :param cas: cell type annotation object to serialize.
@@ -109,10 +111,19 @@ def read_tsv_to_dict(tsv_path, id_column=0, generated_ids=False):
         Function provides two return values: first; headers of the table and second; the TSV content dict. Key of the
         content is the first column value and the values are dict of row values.
     """
-    return read_csv_to_dict(tsv_path, id_column=id_column, delimiter="\t", generated_ids=generated_ids)
+    return read_csv_to_dict(
+        tsv_path, id_column=id_column, delimiter="\t", generated_ids=generated_ids
+    )
 
 
-def read_csv_to_dict(csv_path, id_column=0, id_column_name="", delimiter=",", id_to_lower=False, generated_ids=False):
+def read_csv_to_dict(
+    csv_path,
+    id_column=0,
+    id_column_name="",
+    delimiter=",",
+    id_to_lower=False,
+    generated_ids=False,
+):
     """
     Reads tsv file content into a dict. Key is the first column value and the value is dict representation of the
     row values (each header is a key and column value is the value).
@@ -178,7 +189,7 @@ def read_yaml_config(file_path: str) -> dict:
     """
     with open(file_path, "r") as fs:
         try:
-            ryaml = YAML(typ='safe')
+            ryaml = YAML(typ="safe")
             return ryaml.load(fs)
         except Exception as e:
             raise Exception("Yaml read failed:" + file_path + " " + str(e))
@@ -196,5 +207,7 @@ def read_config(file_path: str) -> dict:
     elif file_extension == ".yaml" or file_extension == ".yml":
         return read_yaml_config(file_path)
     else:
-        raise Exception("Given configuration file extension is not supported. "
-                        "Try a json or yaml file instead of :" + file_path)
+        raise Exception(
+            "Given configuration file extension is not supported. "
+            "Try a json or yaml file instead of :" + file_path
+        )

--- a/src/cas/flatten_data_to_anndata.py
+++ b/src/cas/flatten_data_to_anndata.py
@@ -57,7 +57,6 @@ def flatten(json_file_path, anndata_file_path, validate, output_file_path):
     input_json = read_json_file(json_file_path)
     input_anndata = read_anndata_file(anndata_file_path)
 
-    test_compatibility(input_anndata, input_json, validate)
     # obs
     annotations = input_json[ANNOTATIONS]
 

--- a/src/cas/flatten_data_to_anndata.py
+++ b/src/cas/flatten_data_to_anndata.py
@@ -57,8 +57,7 @@ def flatten(json_file_path, anndata_file_path, validate, output_file_path):
     input_json = read_json_file(json_file_path)
     input_anndata = read_anndata_file(anndata_file_path)
 
-    if validate:
-        test_compatibility(input_anndata, input_json, validate)
+    test_compatibility(input_anndata, input_json, validate)
     # obs
     annotations = input_json[ANNOTATIONS]
 
@@ -68,7 +67,9 @@ def flatten(json_file_path, anndata_file_path, validate, output_file_path):
         cell_ids = []
         if CELL_IDS in ann and ann[CELL_IDS]:
             cell_ids = ann[CELL_IDS]
-        elif "cell_set_accession" in ann and ann["cell_set_accession"] in parent_cell_ids:
+        elif (
+            "cell_set_accession" in ann and ann["cell_set_accession"] in parent_cell_ids
+        ):
             cell_ids = list(parent_cell_ids[ann["cell_set_accession"]])
 
         for k, v in ann.items():
@@ -116,14 +117,19 @@ def collect_parent_cell_ids(cas):
 
     labelsets = sorted(cas[LABELSETS], key=lambda x: int(x["rank"]))
     for labelset in labelsets:
-        ls_annotations = [ann for ann in cas[ANNOTATIONS] if ann["labelset"] == labelset["name"]]
+        ls_annotations = [
+            ann for ann in cas[ANNOTATIONS] if ann["labelset"] == labelset["name"]
+        ]
 
         for ann in ls_annotations:
             if "parent_cell_set_accession" in ann:
                 cell_ids = set()
                 if CELL_IDS in ann and ann[CELL_IDS]:
                     cell_ids = set(ann[CELL_IDS])
-                elif "cell_set_accession" in ann and ann["cell_set_accession"] in parent_cell_ids:
+                elif (
+                    "cell_set_accession" in ann
+                    and ann["cell_set_accession"] in parent_cell_ids
+                ):
                     cell_ids = parent_cell_ids[ann["cell_set_accession"]]
 
                 if ann["parent_cell_set_accession"] in parent_cell_ids:

--- a/src/cas/flatten_data_to_tables.py
+++ b/src/cas/flatten_data_to_tables.py
@@ -20,11 +20,20 @@ def serialize_to_tables(cta, file_name_prefix, out_folder, accession_prefix):
         out_folder: output folder path.
         accession_prefix: accession id prefix
     """
-    annotation_table_path = generate_annotation_table(accession_prefix, cta, file_name_prefix, out_folder)
+    annotation_table_path = generate_annotation_table(
+        accession_prefix, cta, file_name_prefix, out_folder
+    )
     labelset_table_path = generate_labelset_table(cta, file_name_prefix, out_folder)
     metadata_table_path = generate_metadata_table(cta, file_name_prefix, out_folder)
-    annotation_transfer_table_path = generate_annotation_transfer_table(cta, file_name_prefix, out_folder)
-    return [annotation_table_path, labelset_table_path, metadata_table_path, annotation_transfer_table_path]
+    annotation_transfer_table_path = generate_annotation_transfer_table(
+        cta, file_name_prefix, out_folder
+    )
+    return [
+        annotation_table_path,
+        labelset_table_path,
+        metadata_table_path,
+        annotation_transfer_table_path,
+    ]
 
 
 def generate_annotation_transfer_table(cta, file_name_prefix, out_folder):
@@ -42,11 +51,17 @@ def generate_annotation_transfer_table(cta, file_name_prefix, out_folder):
     records = list()
 
     for annotation_object in cta["annotations"]:
-        if ("cell_set_accession" in annotation_object and annotation_object["cell_set_accession"] and
-                "transferred_annotations" in annotation_object and annotation_object["transferred_annotations"]):
+        if (
+            "cell_set_accession" in annotation_object
+            and annotation_object["cell_set_accession"]
+            and "transferred_annotations" in annotation_object
+            and annotation_object["transferred_annotations"]
+        ):
             for ta in annotation_object["transferred_annotations"]:
                 record = dict()
-                record["target_node_accession"] = annotation_object["cell_set_accession"]
+                record["target_node_accession"] = annotation_object[
+                    "cell_set_accession"
+                ]
                 record["transferred_cell_label"] = ta.get("transferred_cell_label", "")
                 record["source_taxonomy"] = ta.get("source_taxonomy", "")
                 record["source_node_accession"] = ta.get("source_node_accession", "")
@@ -84,7 +99,9 @@ def generate_metadata_table(cta, file_name_prefix, out_folder):
     records = list()
 
     record = dict()
-    record["cellannotation_schema_version"] = cta.get("cellannotation_schema_version", "")
+    record["cellannotation_schema_version"] = cta.get(
+        "cellannotation_schema_version", ""
+    )
     record["cellannotation_timestamp"] = cta.get("cellannotation_timestamp", "")
     record["cellannotation_version"] = cta.get("cellannotation_version", "")
     record["cellannotation_url"] = cta.get("cellannotation_url", "")
@@ -122,9 +139,15 @@ def generate_labelset_table(cta, file_name_prefix, out_folder):
             aut_annot = labelset["automated_annotation"]
             name_prefix = "automated_annotation_"
             record[name_prefix + "algorithm_name"] = aut_annot.get("algorithm_name", "")
-            record[name_prefix + "algorithm_version"] = aut_annot.get("algorithm_version", "")
-            record[name_prefix + "algorithm_repo_url"] = aut_annot.get("algorithm_repo_url", "")
-            record[name_prefix + "reference_location"] = aut_annot.get("reference_location", "")
+            record[name_prefix + "algorithm_version"] = aut_annot.get(
+                "algorithm_version", ""
+            )
+            record[name_prefix + "algorithm_repo_url"] = aut_annot.get(
+                "algorithm_repo_url", ""
+            )
+            record[name_prefix + "reference_location"] = aut_annot.get(
+                "reference_location", ""
+            )
         else:
             name_prefix = "automated_annotation_"
             record[name_prefix + "algorithm_name"] = ""
@@ -157,51 +180,88 @@ def generate_annotation_table(accession_prefix, cta, file_name_prefix, out_folde
     std_parent_records_dict = dict()
 
     # sort annotations by accession ids incrementing (if there is)
-    cta["annotations"].sort(key=lambda x: int(str(x["cell_set_accession"]).split("_")[1]) if "cell_set_accession" in x and x["cell_set_accession"] and "_" in x["cell_set_accession"] else 0)
+    cta["annotations"].sort(
+        key=lambda x: int(str(x["cell_set_accession"]).split("_")[1])
+        if "cell_set_accession" in x
+        and x["cell_set_accession"]
+        and "_" in x["cell_set_accession"]
+        else 0
+    )
     for annotation_object in cta["annotations"]:
         record = dict()
-        if "cell_set_accession" in annotation_object and annotation_object["cell_set_accession"]:
-            record["cell_set_accession"] = (accession_manager.generate_accession_id(
-                annotation_object.get("cell_set_accession", "")))
+        if (
+            "cell_set_accession" in annotation_object
+            and annotation_object["cell_set_accession"]
+        ):
+            record["cell_set_accession"] = accession_manager.generate_accession_id(
+                annotation_object.get("cell_set_accession", "")
+            )
             annotation_object["cell_set_accession"] = record["cell_set_accession"]
             record["cell_label"] = annotation_object.get("cell_label", "")
             record["cell_fullname"] = annotation_object.get("cell_fullname", "")
             record["parent_cell_set_accession"] = ""
             record["parent_cell_set_name"] = ""
-            record["labelset"] = str(annotation_object.get("labelset", "")).replace("_name", "")
-            record["cell_ontology_term_id"] = annotation_object.get("cell_ontology_term_id", "")
-            record["cell_ontology_term"] = annotation_object.get("cell_ontology_term", "")
+            record["labelset"] = str(annotation_object.get("labelset", "")).replace(
+                "_name", ""
+            )
+            record["cell_ontology_term_id"] = annotation_object.get(
+                "cell_ontology_term_id", ""
+            )
+            record["cell_ontology_term"] = annotation_object.get(
+                "cell_ontology_term", ""
+            )
             record["rationale"] = annotation_object.get("rationale", "")
-            record["rationale_dois"] = list_to_string(annotation_object.get("rationale_dois", []))
-            record["marker_gene_evidence"] = list_to_string(annotation_object.get("marker_gene_evidence", []))
+            record["rationale_dois"] = list_to_string(
+                annotation_object.get("rationale_dois", [])
+            )
+            record["marker_gene_evidence"] = list_to_string(
+                annotation_object.get("marker_gene_evidence", [])
+            )
             record["synonyms"] = list_to_string(annotation_object.get("synonyms", []))
-            if "user_annotations" in annotation_object and annotation_object["user_annotations"]:
+            if (
+                "user_annotations" in annotation_object
+                and annotation_object["user_annotations"]
+            ):
                 for user_annot in annotation_object["user_annotations"]:
-                    record[normalize_column_name(user_annot["labelset"])] = user_annot["cell_label"]
+                    record[normalize_column_name(user_annot["labelset"])] = user_annot[
+                        "cell_label"
+                    ]
             # record["cell_ids"] = annotation_object.get("cell_ids", "")
             std_records.append(record)
         else:
             # parent nodes
             parent_label = annotation_object["cell_label"]
-            if parent_label not in [parent["cell_label"] for parent in std_parent_records]:
+            if parent_label not in [
+                parent["cell_label"] for parent in std_parent_records
+            ]:
                 record["cell_set_accession"] = ""
                 record["cell_label"] = parent_label
                 record["cell_fullname"] = ""
                 record["parent_cell_set_accession"] = ""
                 record["parent_cell_set_name"] = ""
-                record["labelset"] = str(annotation_object.get("labelset", "")).replace("_name", "")
+                record["labelset"] = str(annotation_object.get("labelset", "")).replace(
+                    "_name", ""
+                )
                 std_parent_records.append(record)
         if "parent_cell_set_name" in annotation_object:
             record["parent_cell_set_name"] = annotation_object["parent_cell_set_name"]
             if annotation_object["parent_cell_set_name"] in std_parent_records_dict:
-                std_parent_records_dict.get(annotation_object["parent_cell_set_name"]).append(record)
+                std_parent_records_dict.get(
+                    annotation_object["parent_cell_set_name"]
+                ).append(record)
             else:
                 children = list()
                 children.append(record)
-                std_parent_records_dict[annotation_object["parent_cell_set_name"]] = children
+                std_parent_records_dict[
+                    annotation_object["parent_cell_set_name"]
+                ] = children
         if "parent_cell_set_accession" in annotation_object:
-            record["parent_cell_set_accession"] = annotation_object["parent_cell_set_accession"]
-    assign_parent_accession_ids(accession_manager, std_parent_records, std_parent_records_dict, cta["labelsets"])
+            record["parent_cell_set_accession"] = annotation_object[
+                "parent_cell_set_accession"
+            ]
+    assign_parent_accession_ids(
+        accession_manager, std_parent_records, std_parent_records_dict, cta["labelsets"]
+    )
     std_records.extend(std_parent_records)
     std_records_df = pd.DataFrame.from_records(std_records)
     std_records_df.to_csv(std_data_path, sep="\t", index=False)
@@ -219,11 +279,13 @@ def list_to_string(my_list: list):
     if not my_list:
         str_value = "[]"
     else:
-        str_value = str(my_list).replace("'", "\"")
+        str_value = str(my_list).replace("'", '"')
     return str_value
 
 
-def assign_parent_accession_ids(accession_manager, std_parent_records, std_parent_records_dict, labelsets):
+def assign_parent_accession_ids(
+    accession_manager, std_parent_records, std_parent_records_dict, labelsets
+):
     """
     Assigns accession ids to parent clusters and updates their references from the child clusters.
     Parameters:
@@ -232,7 +294,12 @@ def assign_parent_accession_ids(accession_manager, std_parent_records, std_paren
         std_parent_records_dict: parent cluster - child clusters dictionary
         labelsets: labelsets list
     """
-    label_set_ranks = dict([(label_set["name"].replace("_name", ""), label_set["rank"]) for label_set in labelsets])
+    label_set_ranks = dict(
+        [
+            (label_set["name"].replace("_name", ""), label_set["rank"])
+            for label_set in labelsets
+        ]
+    )
 
     std_parent_records.sort(key=lambda x: int(label_set_ranks[x["labelset"]]))
     for std_parent_record in std_parent_records:

--- a/src/cas/ingest/config_validator.py
+++ b/src/cas/ingest/config_validator.py
@@ -7,10 +7,12 @@ from jsonschema import Draft7Validator
 
 from cas.file_utils import read_config
 
-SCHEMA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./config_schema.yaml")
+SCHEMA_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "./config_schema.yaml"
+)
 
 
-ryaml = YAML(typ='safe')
+ryaml = YAML(typ="safe")
 with open(SCHEMA_PATH) as stream:
     ctat_schema = ryaml.load(stream)
     validator = Draft7Validator(ctat_schema)
@@ -53,4 +55,3 @@ def validate_json_str(json_str: str) -> bool:
     :return: True if object is valid, False otherwise.
     """
     return validate(json.loads(json_str))
-

--- a/src/cas/ingest/ingest_user_table.py
+++ b/src/cas/ingest/ingest_user_table.py
@@ -3,13 +3,26 @@ import os
 from typing import get_type_hints
 from pathlib import Path
 
-from cas.model import CellTypeAnnotation, Labelset, Annotation, AnnotationTransfer, UserAnnotation, AutomatedAnnotation
+from cas.model import (
+    CellTypeAnnotation,
+    Labelset,
+    Annotation,
+    AnnotationTransfer,
+    UserAnnotation,
+    AutomatedAnnotation,
+)
 from cas.file_utils import write_json_file, read_config, read_tsv_to_dict
 from cas.flatten_data_to_tables import serialize_to_tables
 from cas.ingest.config_validator import validate
 
 
-def ingest_data(data_file: str, config_file: str, out_file: str, format:str = "json", print_undefined: bool = False) -> dict:
+def ingest_data(
+    data_file: str,
+    config_file: str,
+    out_file: str,
+    format: str = "json",
+    print_undefined: bool = False,
+) -> dict:
     """
     Ingests given data into standard cell annotation schema data structure using the given configuration.
 
@@ -68,14 +81,16 @@ def ingest_user_data(data_file: str, config_file: str):
                 ao.rank = int(str(field["rank"]).strip())
                 utilized_columns.add(field["column_name"])
             elif field["column_type"] == "cell_set":
-                parent_ao = Annotation(field["column_name"], record[field["column_name"]])
+                parent_ao = Annotation(
+                    field["column_name"], record[field["column_name"]]
+                )
                 parent_ao.rank = int(str(field["rank"]).strip())
                 parents.insert(int(str(field["rank"]).strip()), parent_ao)
                 utilized_columns.add(field["column_name"])
             else:
                 # handle annotation columns
                 if "typing.List[str]" in str(get_type_hints(ao)[field["column_type"]]):
-                    list_value = str(record[field["column_name"]]).split(',')
+                    list_value = str(record[field["column_name"]]).split(",")
                     stripped = list(map(str.strip, list_value))
                     setattr(ao, field["column_type"], stripped)
                 else:
@@ -98,7 +113,9 @@ def add_user_annotations(ao, headers, record, utilized_columns):
     :param record: a record in the user data
     :param utilized_columns: list of processed columns
     """
-    not_utilized_columns = [column_name for column_name in headers if column_name not in utilized_columns]
+    not_utilized_columns = [
+        column_name for column_name in headers if column_name not in utilized_columns
+    ]
     for not_utilized_column in not_utilized_columns:
         if record[not_utilized_column]:
             ao.add_user_annotation(not_utilized_column, record[not_utilized_column])
@@ -133,9 +150,9 @@ def populate_labelsets(cas, config_fields):
     """
     labelsets = list()
     for field in config_fields:
-        if field['column_type'] == 'cell_set' or field['column_type'] == 'cluster_name':
-            label_set = Labelset(field['column_name'])
-            if 'rank' in field:
+        if field["column_type"] == "cell_set" or field["column_type"] == "cluster_name":
+            label_set = Labelset(field["column_name"])
+            if "rank" in field:
                 label_set.rank = str(field["rank"])
             labelsets.append(label_set)
     if labelsets:

--- a/src/cas/matrix_file/cxg_resolver.py
+++ b/src/cas/matrix_file/cxg_resolver.py
@@ -32,12 +32,23 @@ class CxGDatasetResolver(BaseMatrixFileResolver):
             return os.path.join(self.cache_folder_path, dataset_file_name)
 
         # TODO implement dataset download operation
-        raise Exception("Dataset could not be found at location: '{}'".format(
-            os.path.join(self.cache_folder_path, dataset_file_name)))
+        raise Exception(
+            "Dataset could not be found at location: '{}'".format(
+                os.path.join(self.cache_folder_path, dataset_file_name)
+            )
+        )
 
 
 def list_cached_datasets(cache_folder_path):
     if os.path.isdir(cache_folder_path):
-        return [f for f in os.listdir(cache_folder_path) if os.path.isfile(os.path.join(cache_folder_path, f))]
+        return [
+            f
+            for f in os.listdir(cache_folder_path)
+            if os.path.isfile(os.path.join(cache_folder_path, f))
+        ]
     else:
-        raise Exception("CellxGene dataset cache folder is not accessible: '{}'".format(cache_folder_path))
+        raise Exception(
+            "CellxGene dataset cache folder is not accessible: '{}'".format(
+                cache_folder_path
+            )
+        )

--- a/src/cas/matrix_file/resolver.py
+++ b/src/cas/matrix_file/resolver.py
@@ -6,7 +6,9 @@ from cas.matrix_file.cxg_resolver import CxGDatasetResolver
 CXG_PREFIX = "CellXGene_dataset"
 
 
-def resolve_matrix_file(matrix_file_id: str, cache_folder_path: str = None) -> Optional[anndata.AnnData] :
+def resolve_matrix_file(
+    matrix_file_id: str, cache_folder_path: str = None
+) -> Optional[anndata.AnnData]:
     """
     Resolves matrix file identified by the given matrix_file_id.
 
@@ -27,7 +29,7 @@ def resolve_matrix_file(matrix_file_id: str, cache_folder_path: str = None) -> O
     return resolver.resolve_matrix_file(dataset_id)
 
 
-def resolve_matrix_file_path(matrix_file_id: str, cache_folder_path: str = None) -> str :
+def resolve_matrix_file_path(matrix_file_id: str, cache_folder_path: str = None) -> str:
     """
     Resolves matrix file identified by the given matrix_file_id.
 
@@ -46,6 +48,3 @@ def resolve_matrix_file_path(matrix_file_id: str, cache_folder_path: str = None)
         raise Exception("Unrecognised matrix file protocol: '{}'".format(protocol))
 
     return resolver.resolve_matrix_file_path(dataset_id)
-
-
-

--- a/src/cas/model.py
+++ b/src/cas/model.py
@@ -12,17 +12,15 @@ exclude_none_values = True
 
 
 class EncoderMixin(DataClassJsonMixin):
-
     dataclass_json_config = dataclasses_json.config(
         # letter_case=dataclasses_json.LetterCase.CAMEL,
         undefined=dataclasses_json.Undefined.EXCLUDE,
-        exclude=lambda f: exclude_none_values and f is None
+        exclude=lambda f: exclude_none_values and f is None,
     )["dataclasses_json"]
 
 
 @dataclass
 class AutomatedAnnotation(EncoderMixin):
-
     algorithm_name: str
     """The name of the algorithm used. It MUST be a string of the algorithm's name."""
 
@@ -43,7 +41,6 @@ class AutomatedAnnotation(EncoderMixin):
 
 @dataclass
 class Labelset(EncoderMixin):
-
     name: str
     """name of annotation key"""
 
@@ -65,7 +62,6 @@ class Labelset(EncoderMixin):
 
 @dataclass
 class AnnotationTransfer(EncoderMixin):
-
     transferred_cell_label: Optional[str]
     """Transferred cell label"""
 
@@ -169,12 +165,13 @@ class Annotation(EncoderMixin):
         """
         if not self.user_annotations:
             self.user_annotations = list()
-        self.user_annotations.append(UserAnnotation(user_annotation_set, user_annotation_label))
+        self.user_annotations.append(
+            UserAnnotation(user_annotation_set, user_annotation_label)
+        )
 
 
 @dataclass
 class CellTypeAnnotation(EncoderMixin):
-
     # data_url: str
     # annotation_objects: List[Annotation]
     # taxonomy: TaxonomyMetadata = None
@@ -218,7 +215,9 @@ class CellTypeAnnotation(EncoderMixin):
         global exclude_none_values
         exclude_none_values = value
 
-    def get_all_annotations(self, show_cell_ids: bool = False, labels: list = None) -> pd.DataFrame:
+    def get_all_annotations(
+        self, show_cell_ids: bool = False, labels: list = None
+    ) -> pd.DataFrame:
         """
         Lists all annotations.
 
@@ -228,4 +227,6 @@ class CellTypeAnnotation(EncoderMixin):
         Returns:
             Annotations data frame
         """
-        return get_all_annotations(asdict(self), show_cell_ids=show_cell_ids, labels=labels)
+        return get_all_annotations(
+            asdict(self), show_cell_ids=show_cell_ids, labels=labels
+        )

--- a/src/cas/populate_cell_ids.py
+++ b/src/cas/populate_cell_ids.py
@@ -22,7 +22,7 @@ def populate_cell_ids(cas_json_path: str, anndata_path: str, labelsets: list = N
             with open(cas_json_path, "w") as json_file:
                 json.dump(cas, json_file, indent=2)
     else:
-        raise Exception('Anndata read operation failed: {}'.format(anndata_path))
+        raise Exception("Anndata read operation failed: {}".format(anndata_path))
 
 
 def add_cell_ids(cas: dict, ad: Optional[anndata.AnnData], labelsets: list = None):
@@ -35,7 +35,9 @@ def add_cell_ids(cas: dict, ad: Optional[anndata.AnnData], labelsets: list = Non
         labelsets: List of labelsets to update with IDs from AnnData. If value is null, rank '0' labelset is used.
     """
 
-    rank_zero_labelset = [lbl_set["name"] for lbl_set in cas["labelsets"] if lbl_set["rank"] == "0"][0]
+    rank_zero_labelset = [
+        lbl_set["name"] for lbl_set in cas["labelsets"] if lbl_set["rank"] == "0"
+    ][0]
     if not labelsets:
         labelsets = rank_zero_labelset
 
@@ -48,10 +50,19 @@ def add_cell_ids(cas: dict, ad: Optional[anndata.AnnData], labelsets: list = Non
                 cell_ids = []
                 if cluster_identifier_column.lower() == "cluster_id":
                     cluster_id = anno["user_annotations"][0]["cell_label"]
-                    cell_ids = list(ad.obs.loc[ad.obs["cluster_id"] == int(cluster_id), cluster_identifier_column].index)
+                    cell_ids = list(
+                        ad.obs.loc[
+                            ad.obs["cluster_id"] == int(cluster_id),
+                            cluster_identifier_column,
+                        ].index
+                    )
                 elif cluster_identifier_column.lower() == "cluster":
                     cluster_label = anno["cell_label"]
-                    cell_ids = list(ad.obs.loc[ad.obs[cluster_identifier_column] == cluster_label].index)
+                    cell_ids = list(
+                        ad.obs.loc[
+                            ad.obs[cluster_identifier_column] == cluster_label
+                        ].index
+                    )
                 anno["cell_ids"] = cell_ids
                 if "parent_cell_set_name" in anno:
                     lookup_key = anno["parent_cell_set_name"]
@@ -67,7 +78,9 @@ def add_cell_ids(cas: dict, ad: Optional[anndata.AnnData], labelsets: list = Non
 
         return cas
     else:
-        print("WARN: Cluster identifier column couldn't be identified in OBS. Populate cell ids operation is aborted.")
+        print(
+            "WARN: Cluster identifier column couldn't be identified in OBS. Populate cell ids operation is aborted."
+        )
 
     return None
 
@@ -92,6 +105,7 @@ def get_obs_cluster_identifier_column(ad):
     elif "cluster" in obs_keys:
         cluster_identifier_column = "cluster"
     return cluster_identifier_column
+
 
 # def populate_cell_ids(cas_json_path: str, anndata_path: str, labelsets: list = None):
 #     """

--- a/src/cas/reports.py
+++ b/src/cas/reports.py
@@ -1,7 +1,9 @@
 import pandas as pd
 
 
-def get_all_annotations(cas: dict, show_cell_ids: bool = False, labels: list = None) -> pd.DataFrame:
+def get_all_annotations(
+    cas: dict, show_cell_ids: bool = False, labels: list = None
+) -> pd.DataFrame:
     """
     Lists all annotations.
 
@@ -14,7 +16,7 @@ def get_all_annotations(cas: dict, show_cell_ids: bool = False, labels: list = N
     """
     df = pd.json_normalize(cas["annotations"])
     if not show_cell_ids:
-        df = df.drop('cell_ids', axis=1, errors='ignore')
+        df = df.drop("cell_ids", axis=1, errors="ignore")
 
     if labels:
         mask = df.apply(lambda row: filter_by_label(row, labels), axis=1)
@@ -29,6 +31,6 @@ def filter_by_label(row, labels):
     """
     filter_row = False
     for lbl in labels:
-        if row['labelset'] == lbl[0] and row['cell_label'] == lbl[1]:
+        if row["labelset"] == lbl[0] and row["cell_label"] == lbl[1]:
             filter_row = True
     return filter_row

--- a/src/cas/validate.py
+++ b/src/cas/validate.py
@@ -9,9 +9,11 @@ from cas_schema import schema_validator, schemas
 
 warnings.filterwarnings("always")
 
-SCHEMA_FILE_MAPPING = {"base": "general_schema.json",
-                       "cap": "CAP_schema.json",
-                       "bican": "BICAN_schema.json"}
+SCHEMA_FILE_MAPPING = {
+    "base": "general_schema.json",
+    "cap": "CAP_schema.json",
+    "bican": "BICAN_schema.json",
+}
 
 
 def validate(schema_name: str, data_path: str):
@@ -29,11 +31,13 @@ def validate(schema_name: str, data_path: str):
     if not os.path.exists(data_path):
         raise Exception("Please provide a valid 'data_path': {}".format(data_path))
 
-    schema_file = (resources.files(schemas) / SCHEMA_FILE_MAPPING[schema_name])
+    schema_file = resources.files(schemas) / SCHEMA_FILE_MAPPING[schema_name]
     with schema_file.open("rt") as f:
         schema = json.loads(f.read())
 
-    result = schema_validator.validate(schema, SCHEMA_FILE_MAPPING[schema_name], data_path)
+    result = schema_validator.validate(
+        schema, SCHEMA_FILE_MAPPING[schema_name], data_path
+    )
     if not result:
         raise Exception("Validation Failed")
 

--- a/src/test/config_validator_test.py
+++ b/src/test/config_validator_test.py
@@ -2,13 +2,17 @@ import unittest
 import os
 from cas.ingest.config_validator import validate, validate_json_str, validate_file
 
-VALID_TEST_DATA_1 = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/nhp_basal_ganglia/test_config.yaml")
-INVALID_TEST_DATA_1 = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/nhp_basal_ganglia/test_config_invalid.yaml")
+VALID_TEST_DATA_1 = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "./test_data/nhp_basal_ganglia/test_config.yaml",
+)
+INVALID_TEST_DATA_1 = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "./test_data/nhp_basal_ganglia/test_config_invalid.yaml",
+)
 
 
 class SchemaValidationTests(unittest.TestCase):
-
     def test_validator_yaml(self):
         self.assertTrue(validate_file(VALID_TEST_DATA_1))
         self.assertFalse(validate_file(INVALID_TEST_DATA_1))
-

--- a/src/test/flatten_data_to_tables_test.py
+++ b/src/test/flatten_data_to_tables_test.py
@@ -6,12 +6,23 @@ from cas.ingest.ingest_user_table import ingest_user_data
 from cas.flatten_data_to_tables import serialize_to_tables
 from cas.file_utils import read_csv_to_dict, read_cas_json_file
 
-RAW_DATA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/nhp_basal_ganglia/AIT115_annotation_sheet.tsv")
-TEST_CONFIG = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/nhp_basal_ganglia/test_config.yaml")
+RAW_DATA = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "./test_data/nhp_basal_ganglia/AIT115_annotation_sheet.tsv",
+)
+TEST_CONFIG = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "./test_data/nhp_basal_ganglia/test_config.yaml",
+)
 
-TEST_JSON = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/siletti/Siletti_all_non_neuronal_cells_with_cids.json")
+TEST_JSON = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "./test_data/siletti/Siletti_all_non_neuronal_cells_with_cids.json",
+)
 
-OUT_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/table_out/")
+OUT_FOLDER = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "./test_data/table_out/"
+)
 
 
 class TabularSerialisationTests(unittest.TestCase):
@@ -36,31 +47,33 @@ class TabularSerialisationTests(unittest.TestCase):
         self.assertEqual(annotation_table_path, tables[0])
         self.assertTrue(os.path.isfile(annotation_table_path))
 
-        headers, records = read_csv_to_dict(annotation_table_path, id_column_name="cell_set_accession", delimiter="\t")
+        headers, records = read_csv_to_dict(
+            annotation_table_path, id_column_name="cell_set_accession", delimiter="\t"
+        )
         self.assertEqual(354, len(records))
 
-        cluster_1 = records['TST_1']
+        cluster_1 = records["TST_1"]
         self.assertEqual("1_MSN", cluster_1["cell_label"])
         self.assertEqual("TST_300", cluster_1["parent_cell_set_accession"])
         self.assertEqual("D1-Matrix", cluster_1["parent_cell_set_name"])
         self.assertEqual("cluster", cluster_1["labelset"])
-        self.assertEqual("[\"EPYC\", \"RELN\", \"GULP1\"]", cluster_1["marker_gene_evidence"])
+        self.assertEqual('["EPYC", "RELN", "GULP1"]', cluster_1["marker_gene_evidence"])
         self.assertEqual("PuR(0.52) | CaH(0.39)", cluster_1["region.info _Frequency_"])
         # self.assertEqual("", cluster_1["cell_ids"])
 
-        cluster_300 = records['TST_300']
+        cluster_300 = records["TST_300"]
         self.assertEqual("D1-Matrix", cluster_300["cell_label"])
         self.assertEqual("TST_339", cluster_300["parent_cell_set_accession"])
         self.assertEqual("D1-MSN", cluster_300["parent_cell_set_name"])
         self.assertEqual("level 3 (subclass)", cluster_300["labelset"])
 
-        cluster_339 = records['TST_339']
+        cluster_339 = records["TST_339"]
         self.assertEqual("D1-MSN", cluster_339["cell_label"])
         self.assertEqual("TST_365", cluster_339["parent_cell_set_accession"])
         self.assertEqual("MSN", cluster_339["parent_cell_set_name"])
         self.assertEqual("level 2 (neighborhood)", cluster_339["labelset"])
 
-        cluster_365 = records['TST_365']
+        cluster_365 = records["TST_365"]
         self.assertEqual("MSN", cluster_365["cell_label"])
         self.assertEqual("", cluster_365["parent_cell_set_accession"])
         self.assertEqual("", cluster_365["parent_cell_set_name"])
@@ -74,10 +87,12 @@ class TabularSerialisationTests(unittest.TestCase):
         self.assertEqual(table_path, tables[1])
         self.assertTrue(os.path.isfile(table_path))
 
-        headers, records = read_csv_to_dict(table_path, id_column_name="name", delimiter="\t")
+        headers, records = read_csv_to_dict(
+            table_path, id_column_name="name", delimiter="\t"
+        )
         self.assertEqual(4, len(records))
 
-        cluster_ls = records['cluster']
+        cluster_ls = records["cluster"]
         self.assertEqual("0", cluster_ls["rank"])
         self.assertEqual("", cluster_ls["annotation_method"])
         self.assertEqual("", cluster_ls["automated_annotation_algorithm_name"])
@@ -94,7 +109,9 @@ class TabularSerialisationTests(unittest.TestCase):
         self.assertEqual(table_path, tables[2])
         self.assertTrue(os.path.isfile(table_path))
 
-        headers, records = read_csv_to_dict(table_path, generated_ids=True, delimiter="\t")
+        headers, records = read_csv_to_dict(
+            table_path, generated_ids=True, delimiter="\t"
+        )
         self.assertEqual(1, len(records))
 
         self.assertEqual("Test User", records[1]["author_name"])
@@ -109,7 +126,9 @@ class TabularSerialisationTests(unittest.TestCase):
         self.assertEqual(table_path, tables[3])
         self.assertTrue(os.path.isfile(table_path))
 
-        headers, records = read_csv_to_dict(table_path, generated_ids=True, delimiter="\t")
+        headers, records = read_csv_to_dict(
+            table_path, generated_ids=True, delimiter="\t"
+        )
         self.assertEqual(1, len(records))
 
         self.assertEqual("", records[1]["target_node_accession"])
@@ -125,7 +144,9 @@ class TabularSerialisationTests(unittest.TestCase):
         self.assertEqual(annotation_table_path, tables[0])
         self.assertTrue(os.path.isfile(annotation_table_path))
 
-        headers, records = read_csv_to_dict(annotation_table_path, id_column_name="cell_set_accession", delimiter="\t")
+        headers, records = read_csv_to_dict(
+            annotation_table_path, id_column_name="cell_set_accession", delimiter="\t"
+        )
         self.assertEqual(89, len(records))
 
         # cluster_1 = records['TST_1']
@@ -135,4 +156,3 @@ class TabularSerialisationTests(unittest.TestCase):
         # self.assertEqual("cluster", cluster_1["labelset"])
         # self.assertEqual("[\"EPYC\", \"RELN\", \"GULP1\"]", cluster_1["marker_gene_evidence"])
         # self.assertEqual("PuR(0.52) | CaH(0.39)", cluster_1["region.info _Frequency_"])
-

--- a/src/test/ingest_user_table_test.py
+++ b/src/test/ingest_user_table_test.py
@@ -3,9 +3,18 @@ import os
 
 from cas.ingest.ingest_user_table import ingest_data
 
-RAW_DATA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/nhp_basal_ganglia/AIT115_annotation_sheet.tsv")
-TEST_CONFIG = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/nhp_basal_ganglia/test_config.yaml")
-OUT_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/nhp_basal_ganglia/test_result.json")
+RAW_DATA = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "./test_data/nhp_basal_ganglia/AIT115_annotation_sheet.tsv",
+)
+TEST_CONFIG = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "./test_data/nhp_basal_ganglia/test_config.yaml",
+)
+OUT_FILE = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "./test_data/nhp_basal_ganglia/test_result.json",
+)
 
 
 class CellTypeAnnotationTests(unittest.TestCase):
@@ -33,7 +42,9 @@ class CellTypeAnnotationTests(unittest.TestCase):
         self.assertEqual(354, len(result["annotations"]))
         # print(result["annotations"][:10])
 
-        test_annotation = [x for x in result["annotations"] if x["cell_label"] == "1_MSN"][0]
+        test_annotation = [
+            x for x in result["annotations"] if x["cell_label"] == "1_MSN"
+        ][0]
         self.assertTrue("marker_gene_evidence" in test_annotation)
         self.assertEqual(3, len(test_annotation["marker_gene_evidence"]))
         self.assertTrue("EPYC" in test_annotation["marker_gene_evidence"])

--- a/src/test/reports_test.py
+++ b/src/test/reports_test.py
@@ -6,13 +6,15 @@ from dataclasses import asdict
 from cas.reports import get_all_annotations
 from cas.file_utils import read_cas_json_file
 
-TEST_JSON = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/siletti/Siletti_all_non_neuronal_cells_with_cids.json")
+TEST_JSON = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "./test_data/siletti/Siletti_all_non_neuronal_cells_with_cids.json",
+)
 
 
 class ReportsTests(unittest.TestCase):
-
     def setUp(self):
-        pd.set_option('display.max_columns', None)
+        pd.set_option("display.max_columns", None)
 
     def test_annotations_listing(self):
         cas = read_cas_json_file(TEST_JSON)
@@ -36,10 +38,14 @@ class ReportsTests(unittest.TestCase):
         cas = read_cas_json_file(TEST_JSON)
         self.assertEqual(89, len(cas.annotations))
 
-        df = cas.get_all_annotations(labels=[("Supercluster", "Microglia"),
-                                             ("Cluster", "Mgl_4"),
-                                             ("Cluster", "Astro_55"),
-                                             ("Dummy", "Dummy")])
+        df = cas.get_all_annotations(
+            labels=[
+                ("Supercluster", "Microglia"),
+                ("Cluster", "Mgl_4"),
+                ("Cluster", "Astro_55"),
+                ("Dummy", "Dummy"),
+            ]
+        )
         print(df)
         self.assertEqual(3, df.shape[0])
         self.assertEqual(14, df.shape[1])
@@ -55,6 +61,3 @@ class ReportsTests(unittest.TestCase):
         # print(df)
         self.assertEqual(89, df.shape[0])
         self.assertEqual(14, df.shape[1])
-
-
-

--- a/src/test/test_data/hash/hash_demo.py
+++ b/src/test/test_data/hash/hash_demo.py
@@ -3,8 +3,10 @@ import os
 from cas.file_utils import read_cas_json_file, write_json_file
 from cas.accession.hash_accession_manager import HashAccessionManager
 
-CAS_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                        "../siletti/Siletti_all_non_neuronal_cells_with_cids.json")
+CAS_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "../siletti/Siletti_all_non_neuronal_cells_with_cids.json",
+)
 
 
 def main():
@@ -13,7 +15,9 @@ def main():
     cas = read_cas_json_file(CAS_PATH)
     print(len(cas.annotations))
     for annotation in cas.annotations:
-        annotation.cell_set_accession = accession_manager.generate_accession_id(cell_ids=annotation.cell_ids)
+        annotation.cell_set_accession = accession_manager.generate_accession_id(
+            cell_ids=annotation.cell_ids
+        )
 
     write_json_file(cas, "hash_demo.json")
 

--- a/src/test/test_data/siletti/converter/siletti_cas_converter.py
+++ b/src/test/test_data/siletti/converter/siletti_cas_converter.py
@@ -2,19 +2,32 @@
 
 import os
 
-from cas.model import (CellTypeAnnotation, Annotation, Labelset, AnnotationTransfer,
-                       UserAnnotation, AutomatedAnnotation)
+from cas.model import (
+    CellTypeAnnotation,
+    Annotation,
+    Labelset,
+    AnnotationTransfer,
+    UserAnnotation,
+    AutomatedAnnotation,
+)
 from cas.file_utils import read_csv_to_dict, write_json_file
 from cas.accession.incremental_accession_manager import IncrementalAccessionManager
 
-CLUSTERS_TSV = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                            "../spreadsheet/Siletti_for review - all_clusters.tsv")
-N_SUPER_CLUSTERS_TSV = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                    "../spreadsheet/Siletti_for review - neuron_supercluster.tsv")
-NN_SUPER_CLUSTERS_TSV = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                     "../spreadsheet/Siletti_for review - non-neuronal_supercluster.tsv")
-NOMENCLATURE_TABLE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                     "../nomenclature_table_CS202210140.csv")
+CLUSTERS_TSV = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "../spreadsheet/Siletti_for review - all_clusters.tsv",
+)
+N_SUPER_CLUSTERS_TSV = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "../spreadsheet/Siletti_for review - neuron_supercluster.tsv",
+)
+NN_SUPER_CLUSTERS_TSV = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "../spreadsheet/Siletti_for review - non-neuronal_supercluster.tsv",
+)
+NOMENCLATURE_TABLE = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "../nomenclature_table_CS202210140.csv"
+)
 
 
 def main():
@@ -31,12 +44,18 @@ def main():
     cas_neuronal.labelsets = labelsets
     cas_non_neuronal.labelsets = labelsets
 
-    nm_headers, nm_records = read_csv_to_dict(NOMENCLATURE_TABLE, id_column_name="cell_set_preferred_alias")
-    last_accession_id = str(nm_records[list(nm_records.keys())[-1]]["cell_set_accession"]).split("_")
+    nm_headers, nm_records = read_csv_to_dict(
+        NOMENCLATURE_TABLE, id_column_name="cell_set_preferred_alias"
+    )
+    last_accession_id = str(
+        nm_records[list(nm_records.keys())[-1]]["cell_set_accession"]
+    ).split("_")
     accession_prefix = last_accession_id[0] + "_"
     last_accession_number = int(last_accession_id[1])
 
-    accession_manager = IncrementalAccessionManager(accession_prefix=accession_prefix, last_accession_id=last_accession_number)
+    accession_manager = IncrementalAccessionManager(
+        accession_prefix=accession_prefix, last_accession_id=last_accession_number
+    )
 
     annotations_neuronal = list()
     annotations_non_neuronal = list()
@@ -46,7 +65,9 @@ def main():
         record = nsc_records[record_key]
         annotation = Annotation("", "")
         annotation.labelset = "supercluster_term"
-        extract_annotation_data(record, record_key, annotation, nm_records, accession_manager)
+        extract_annotation_data(
+            record, record_key, annotation, nm_records, accession_manager
+        )
         annotations_neuronal.append(annotation)
 
     nnsc_headers, nnsc_records = read_csv_to_dict(NN_SUPER_CLUSTERS_TSV, delimiter="\t")
@@ -54,27 +75,41 @@ def main():
         record = nnsc_records[record_key]
         annotation = Annotation("", "")
         annotation.labelset = "supercluster_term"
-        extract_annotation_data(record, record_key, annotation, nm_records, accession_manager)
+        extract_annotation_data(
+            record, record_key, annotation, nm_records, accession_manager
+        )
         annotations_non_neuronal.append(annotation)
 
-    headers, records = read_csv_to_dict(CLUSTERS_TSV, id_column_name="Cluster ID", delimiter="\t")
+    headers, records = read_csv_to_dict(
+        CLUSTERS_TSV, id_column_name="Cluster ID", delimiter="\t"
+    )
     for record_key in records:
         record = records[record_key]
         annotation = Annotation("", "")
         annotation.labelset = "Cluster"
 
-        extract_annotation_data(record, record_key, annotation, nm_records, accession_manager)
+        extract_annotation_data(
+            record, record_key, annotation, nm_records, accession_manager
+        )
 
         if record.get("Supercluster", "") in nsc_records:
             annotation.parent_cell_set_name = record.get("Supercluster", "")
-            annotation.parent_cell_set_accession = get_accession(annotations_neuronal, annotation.parent_cell_set_name)
+            annotation.parent_cell_set_accession = get_accession(
+                annotations_neuronal, annotation.parent_cell_set_name
+            )
             annotations_neuronal.append(annotation)
         elif record.get("Supercluster", "") in nnsc_records:
             annotation.parent_cell_set_name = record.get("Supercluster", "")
-            annotation.parent_cell_set_accession = get_accession(annotations_non_neuronal, annotation.parent_cell_set_name)
+            annotation.parent_cell_set_accession = get_accession(
+                annotations_non_neuronal, annotation.parent_cell_set_name
+            )
             annotations_non_neuronal.append(annotation)
         else:
-            raise Exception("Supercluster not found: {} at {}".format(record.get("Supercluster", ""), annotation.cell_label))
+            raise Exception(
+                "Supercluster not found: {} at {}".format(
+                    record.get("Supercluster", ""), annotation.cell_label
+                )
+            )
 
     cas_neuronal.annotations = annotations_neuronal
     cas_non_neuronal.annotations = annotations_non_neuronal
@@ -83,7 +118,9 @@ def main():
     write_json_file(cas_non_neuronal, "../Siletti_all_non_neuronal_cells.json")
 
 
-def extract_annotation_data(record, record_key, annotation, nm_records, accession_manager):
+def extract_annotation_data(
+    record, record_key, annotation, nm_records, accession_manager
+):
     if "Cluster name" in record:
         annotation.cell_label = record.get("Cluster name", "")
     elif "SUPERCLUSTER" in record:
@@ -93,19 +130,29 @@ def extract_annotation_data(record, record_key, annotation, nm_records, accessio
     annotation.cell_ontology_term_id = record.get("CELL_ONTOLOGY_TERM_ID", "")
     annotation.cell_ontology_term = record.get("CELL_ONTOLOGY_TERM", "")
     annotation.rationale = record.get("RATIONALE", "")
-    annotation.rationale_dois = [x.strip() for x in record.get("RATIONALE_DOI", "").split(",")]
-    annotation.marker_gene_evidence = [x.strip() for x in record.get("POSITIVE_GENE_EVIDENCE", "").split(",")]
+    annotation.rationale_dois = [
+        x.strip() for x in record.get("RATIONALE_DOI", "").split(",")
+    ]
+    annotation.marker_gene_evidence = [
+        x.strip() for x in record.get("POSITIVE_GENE_EVIDENCE", "").split(",")
+    ]
     if "Cluster ID" in record:
         annotation.add_user_annotation("Cluster ID", record["Cluster ID"])
 
     if "Cluster name" in record:
         if record["Cluster name"] and record["Cluster name"] in nm_records:
-            annotation.cell_set_accession = nm_records[record["Cluster name"]]["cell_set_accession"]
+            annotation.cell_set_accession = nm_records[record["Cluster name"]][
+                "cell_set_accession"
+            ]
         else:
-            raise Exception("AccessionId couldn't be identified for: {}".format(record_key))
+            raise Exception(
+                "AccessionId couldn't be identified for: {}".format(record_key)
+            )
     elif "SUPERCLUSTER" in record:
         if record["SUPERCLUSTER"] and record["SUPERCLUSTER"] in nm_records:
-            annotation.cell_set_accession = nm_records[record["SUPERCLUSTER"]]["cell_set_accession"]
+            annotation.cell_set_accession = nm_records[record["SUPERCLUSTER"]][
+                "cell_set_accession"
+            ]
         else:
             annotation.cell_set_accession = accession_manager.generate_accession_id()
 

--- a/src/test/test_suite.py
+++ b/src/test/test_suite.py
@@ -1,7 +1,7 @@
 import unittest
 
 loader = unittest.TestLoader()
-suite = loader.discover(start_dir='../', pattern='*_test.py')
+suite = loader.discover(start_dir="../", pattern="*_test.py")
 
 runner = unittest.TextTestRunner()
 runner.run(suite)

--- a/src/test/validator_test.py
+++ b/src/test/validator_test.py
@@ -6,14 +6,17 @@ from cas.validate import validate
 
 warnings.filterwarnings("always")
 
-TEST_JSON = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                         "./test_data/validation/BICAN_schema_specific_examples/Silletti_annotation_transfer.json")
-TEST_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                           "./test_data/validation/BICAN_schema_specific_examples")
+TEST_JSON = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "./test_data/validation/BICAN_schema_specific_examples/Silletti_annotation_transfer.json",
+)
+TEST_FOLDER = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "./test_data/validation/BICAN_schema_specific_examples",
+)
 
 
 class ValidatorTests(unittest.TestCase):
-
     def test_file_validation(self):
         try:
             validate("cap", TEST_JSON)
@@ -31,4 +34,3 @@ class ValidatorTests(unittest.TestCase):
             self.assertEqual("Validation Failed", e.args[0])
 
         self.assertTrue(validate("bican", TEST_FOLDER))
-


### PR DESCRIPTION
Address Inconsistencies in validate Argument Usage, fixes #23 

In flatten_data_to_anndata.py and anndata_conversion.py, there were inconsistencies in the usage of the 'validate' argument before the 'test_compatibility' method. I've adjusted the code so that the 'test_compatibility' method in flatten_data_to_anndata.py is now called without checking the 'validate' argument. This change ensures that the method is invoked consistently, allowing for warnings without terminating the run. Users can now modify the labelset in any cell sets when they don't use the validate argument in CLI.

Additionally, applied code formatting using Black to maintain consistency across the src folder.

