### PR TITLE
H5ad workaround for flatten method

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,14 +27,14 @@ Key Features:
 Detailed specification about the `flatten` operation can be found in the [related issue](https://github.com/cellannotation/cas-tools/issues/7).
 
 ```commandline
-cas flatten --json path/to/json_file.json --anndata path/to/anndata_file.h5ad --validate --output path/to/output_file.h5ad
+cas flatten --json path/to/json_file.json --anndata path/to/anndata_file.h5ad --output path/to/output_file.h5ad
 ```
 
 **Command-line Arguments:**
 - `--json`      : Path to the CAS JSON schema file.
 - `--anndata`   : Path to the AnnData file. Ideally, the location will be specified by a resolvable path in the CAS file.
-- `--validate`  : (Optional) Perform validation checks before flattening to the output AnnData file.
-- `--output`    : Output AnnData file name (default: output.h5ad).
+- `--output`    : Optional output AnnData file name. If provided a new flatten anndata file will be created,
+    otherwise the inputted anndata file will be updated with the flatten data.
 
 Please check the [related notebook](../notebooks/test_flatten.ipynb) to evaluate the output data format.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
-anndata==0.10.3
+anndata==0.10.5
 cellxgene-census
 openpyxl
 dataclasses_json
-pandas
+pandas>=2.1.1
 ruamel.yaml
-jsonschema==4.4.0
+jsonschema>=4.21.1
 ordered-set==4.1.0
 deepmerge==1.1.0
 cell-annotation-schema
+h5py>=3.10.0
+numpy>=1.23.5
+setuptools>=65.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-anndata==0.10.5
+anndata==0.10.3
 cellxgene-census
 openpyxl
 dataclasses_json
-pandas>=2.1.1
+pandas
 ruamel.yaml
-jsonschema>=4.21.1
+jsonschema==4.4.0
 ordered-set==4.1.0
 deepmerge==1.1.0
 cell-annotation-schema

--- a/src/cas/__main__.py
+++ b/src/cas/__main__.py
@@ -1,13 +1,13 @@
 import argparse
+import os
 import pathlib
-import sys
 import warnings
 
 from cas.anndata_conversion import merge
+from cas.anndata_to_cas import anndata2cas
 from cas.flatten_data_to_anndata import flatten
 from cas.populate_cell_ids import populate_cell_ids
 from cas.spreadsheet_to_cas import spreadsheet2cas
-from cas.anndata_to_cas import anndata2cas
 from cas.validate import validate as schema_validate
 
 warnings.filterwarnings("always")
@@ -44,7 +44,7 @@ def main():
         anndata_file_path = args.anndata
         output_file_path = args.output
 
-        if output_file_path and anndata_file_path == output_file_path:
+        if output_file_path and os.path.abspath(anndata_file_path) == os.path.abspath(output_file_path):
             raise ValueError("--anndata and --output cannot be the same")
 
         flatten(json_file_path, anndata_file_path, output_file_path)

--- a/src/cas/__main__.py
+++ b/src/cas/__main__.py
@@ -41,12 +41,11 @@ def main():
         json_file_path = args.json
         anndata_file_path = args.anndata
         output_file_path = args.output
-        validate = args.validate
 
-        if anndata_file_path == output_file_path:
+        if output_file_path and anndata_file_path == output_file_path:
             raise ValueError("--anndata and --output cannot be the same")
 
-        flatten(json_file_path, anndata_file_path, validate, output_file_path)
+        flatten(json_file_path, anndata_file_path, output_file_path)
     elif args.action == "spreadsheet2cas":
         args = parser.parse_args()
         spreadsheet_file_path = args.spreadsheet
@@ -119,8 +118,8 @@ def create_flatten_operation_parser(subparsers):
     -----------------------
     --json      : Path to the CAS JSON schema file.
     --anndata   : Path to the AnnData file. Ideally, the location will be specified by a resolvable path in the CAS file.
-    --validate  : Perform validation checks before flattening to AnnData file.
-    --output    : Output AnnData file name (default: output.h5ad).
+    --output    : Optional output AnnData file name. If provided a new flatten anndata file will be created,
+    otherwise the inputted anndata file will be updated with the flatten data.
 
     Usage Example:
     --------------
@@ -139,15 +138,9 @@ def create_flatten_operation_parser(subparsers):
         "--anndata", required=True, help="Input AnnData file path"
     )
     parser_flatten.add_argument(
-        "-v",
-        "--validate",
-        action="store_true",
-        help="Perform validation checks before writing to the output AnnData file.",
-    )
-    parser_flatten.add_argument(
         "--output",
+        required=False,
         help="Output AnnData file name (default: output.h5ad)",
-        default="output.h5ad",
     )
     parser_flatten.set_defaults(validate=False)
 

--- a/src/cas/file_utils.py
+++ b/src/cas/file_utils.py
@@ -4,6 +4,7 @@ import pathlib
 from typing import Optional
 
 import anndata
+import numpy as np
 from ruamel.yaml import YAML
 
 from cas.model import CellTypeAnnotation

--- a/src/cas/flatten_data_to_anndata.py
+++ b/src/cas/flatten_data_to_anndata.py
@@ -11,9 +11,13 @@ Key Features:
 3. Updates the AnnData object with information from the JSON annotations and root keys.
 4. Writes the modified AnnData object to a specified output file.
 """
+import shutil
 
-from cas.anndata_conversion import test_compatibility
-from cas.file_utils import read_anndata_file, read_json_file
+import h5py
+import numpy as np
+import pandas as pd
+
+from cas.file_utils import read_json_file
 
 LABELSET_NAME = "name"
 
@@ -43,7 +47,7 @@ def is_list_of_strings(var):
     return isinstance(var, list) and all(isinstance(item, str) for item in var)
 
 
-def flatten(json_file_path, anndata_file_path, validate, output_file_path):
+def flatten(json_file_path, anndata_file_path, output_file_path):
     """
      Processes and integrates information from a JSON file and an AnnData (Annotated Data) file, creating a new AnnData
      object that incorporates the metadata. The resulting AnnData object is then saved to a new file.
@@ -51,59 +55,113 @@ def flatten(json_file_path, anndata_file_path, validate, output_file_path):
     Args:
         json_file_path: The path to the CAS json file.
         anndata_file_path: The path to the AnnData file.
-        validate: Boolean to determine if validation checks will be performed before writing to the output AnnData file.
         output_file_path: Output AnnData file name.
     """
     input_json = read_json_file(json_file_path)
-    input_anndata = read_anndata_file(anndata_file_path)
 
-    flatten_cas_object(input_json, input_anndata, validate, output_file_path)
+    flatten_cas_object(input_json, anndata_file_path, output_file_path)
 
 
-def flatten_cas_object(input_json, input_anndata, validate, output_file_path):
+# @profile
+def flatten_cas_object(input_json, anndata_file_path, output_file_path):
     """
      Processes and integrates information from a JSON file and an AnnData (Annotated Data) file, creating a new AnnData
      object that incorporates the metadata. The resulting AnnData object is then saved to a new file.
 
     Args:
         input_json: CAS json file.
-        input_anndata: The AnnData object.
-        validate: Boolean to determine if validation checks will be performed before writing to the output AnnData file.
+        anndata_file_path: The path to the AnnData file.
         output_file_path: Output AnnData file name.
     """
-    # obs
-    annotations = input_json[ANNOTATIONS]
+    if output_file_path:
+        shutil.copy(anndata_file_path, output_file_path)
+        anndata_file_path = output_file_path
 
+    annotations = input_json[ANNOTATIONS]
     parent_cell_ids = collect_parent_cell_ids(input_json)
 
+    with h5py.File(anndata_file_path, "r+") as f:
+        obs_dataset = f["obs"]
+        obs_index = np.array(obs_dataset["CellID"], dtype=str)
+
+        # obs
+        flatten_data = process_annotations(annotations, obs_index, parent_cell_ids)
+        update_obs_dataset(obs_dataset, flatten_data)
+
+        # uns
+        uns_json = generate_uns_json(input_json)
+        uns_dataset = f["uns"]
+        write_json_to_hdf5(uns_dataset, uns_json)
+
+
+def process_annotations(annotations, obs_index, parent_cell_ids):
+    """
+    Processes annotations and generates flattened data for obs dataset.
+
+    Args:
+        annotations (list): List of annotations.
+        obs_index (np.ndarray): Array representing the index of the obs dataset.
+        parent_cell_ids (dict): Dictionary containing parent cell ids.
+
+    Returns:
+        dict: Dictionary containing flattened data.
+    """
+    flatten_data = {}
     for ann in annotations:
-        cell_ids = []
-        if CELL_IDS in ann and ann[CELL_IDS]:
-            cell_ids = ann[CELL_IDS]
-        elif (
-            "cell_set_accession" in ann and ann["cell_set_accession"] in parent_cell_ids
-        ):
-            cell_ids = list(parent_cell_ids[ann["cell_set_accession"]])
+        cell_ids = ann.get(
+            CELL_IDS, parent_cell_ids.get(ann.get("cell_set_accession", []))
+        )
+        # Convert cell_ids to a list if it's not already for np.isin
+        if not isinstance(cell_ids, list):
+            cell_ids = list(cell_ids)
 
         for k, v in ann.items():
-            if k == CELL_IDS or k == LABELSET:
+            if k in [CELL_IDS, LABELSET]:
                 continue
-            # if k == CELL_LABEL:
-            #     key = ann[LABELSET]
-            else:
-                key = f"{ann[LABELSET]}--{k}"
+            key = f"{ann[LABELSET]}--{k}"
+            value = ", ".join(
+                sorted([str(value) for value in v] if isinstance(v, list) else [str(v)])
+            )
+            mask = np.isin(obs_index, cell_ids)
+            new_array = pd.Series("", index=obs_index)
+            new_array[mask] = value
+            if key in flatten_data:
+                mask1 = new_array != ""
+                mask2 = flatten_data[key] != ""
+                new_array[~mask1 & mask2] = flatten_data[key][~mask1 & mask2]
+            flatten_data[key] = new_array
+    return flatten_data
 
-            value = v
-            if isinstance(v, list):
-                non_dict_v = [value for value in v if not isinstance(value, dict)]
-                value = ", ".join(sorted(non_dict_v))
-                if len(v) > len(non_dict_v):
-                    print("WARN: dict values are excluded on field '{}'".format(key))
-                input_anndata.obs[key] = ""
 
-            for index_to_insert in cell_ids:
-                input_anndata.obs.at[index_to_insert, key] = value
-    # uns
+def update_obs_dataset(obs_dataset, flatten_data):
+    """
+    Updates obs dataset with flattened data.
+
+    Args:
+        obs_dataset (h5py.Dataset): Dataset representing the obs field in the AnnData file.
+        flatten_data (dict): Dictionary containing flattened data.
+    """
+    for key, value in flatten_data.items():
+        obs_dataset.create_dataset(key, data=value.values.astype("O"))
+        columns = np.append(obs_dataset.attrs["column-order"], key)
+        obs_dataset.attrs["column-order"] = columns
+
+
+def generate_uns_json(input_json):
+    """
+    Generates a dictionary representing the uns (unstructured) field in an AnnData object from a given JSON input.
+
+    This function processes information from a JSON input and generates a dictionary that represents the uns (unstructured)
+    field in an AnnData object. The resulting dictionary can be used to populate the uns field in the AnnData object.
+
+    Args:
+        input_json (dict): A dictionary representing the input JSON data containing annotations.
+
+    Returns:
+        dict: A dictionary representing the uns (unstructured) field in an AnnData object, ready to be used as input
+              for writing to an AnnData file.
+
+    """
     uns_json = {}
     root_keys = list(input_json.keys())
     root_keys.remove(ANNOTATIONS)
@@ -120,13 +178,49 @@ def flatten_cas_object(input_json, input_anndata, validate, output_file_path):
                         continue
                     new_key = f"{labelset.get(LABELSET_NAME, '')}--{k}"
                     uns_json.update({new_key: v})
-    input_anndata.uns.update(uns_json)
-    # Close the AnnData file to prevent blocking
-    input_anndata.file.close()
-    input_anndata.write(output_file_path)
+    return uns_json
+
+
+def write_json_to_hdf5(group, data):
+    """
+    Recursively writes JSON-like data to an HDF5 group.
+
+    Args:
+        group (h5py.Group): The HDF5 group to write data to.
+        data (dict): A dictionary containing the data to be written.
+
+    Returns:
+        None
+    """
+    for key, value in data.items():
+        if isinstance(value, dict):
+            subgroup = group.create_group(key)
+            write_json_to_hdf5(subgroup, value)
+        elif isinstance(value, list):
+            if all(isinstance(item, str) for item in value):
+                group.create_dataset(key, data=", ".join(sorted(value)))
+            else:
+                subgroup = group.create_group(key)
+                for i, item in enumerate(value):
+                    subgroup.create_dataset(str(i), data=item)
+        else:
+            group.create_dataset(key, data=value)
 
 
 def collect_parent_cell_ids(cas):
+    """
+        Collects parent cell IDs from the given CAS (Cluster Annotation Service) data.
+
+        This function iterates through labelsets in the CAS data and collects parent cell IDs
+        associated with each labelset annotation. It populates and returns a dictionary
+        mapping parent cell set accessions to sets of corresponding cell IDs.
+
+        Args:
+            cas (dict): The Cluster Annotation Service data containing labelsets and annotations.
+
+        Returns:
+            dict: A dictionary mapping parent cell set accessions to sets of corresponding cell IDs.
+        """
     parent_cell_ids = dict()
 
     labelsets = sorted(cas[LABELSETS], key=lambda x: int(x["rank"]))

--- a/src/cas/flatten_data_to_anndata.py
+++ b/src/cas/flatten_data_to_anndata.py
@@ -114,22 +114,22 @@ def process_annotations(annotations, obs_index, parent_cell_ids):
         # Convert cell_ids to a list if it's not already for np.isin
         if not isinstance(cell_ids, list):
             cell_ids = list(cell_ids)
+        mask = np.isin(obs_index, cell_ids)
 
         for k, v in ann.items():
             if k in [CELL_IDS, LABELSET]:
                 continue
+
             key = f"{ann[LABELSET]}--{k}"
             value = ", ".join(
                 sorted([str(value) for value in v] if isinstance(v, list) else [str(v)])
             )
-            mask = np.isin(obs_index, cell_ids)
-            new_array = pd.Series("", index=obs_index)
+
+            if key not in flatten_data:
+                flatten_data[key] = pd.Series("", index=obs_index)
+            new_array = flatten_data[key]
             new_array[mask] = value
-            if key in flatten_data:
-                mask1 = new_array != ""
-                mask2 = flatten_data[key] != ""
-                new_array[~mask1 & mask2] = flatten_data[key][~mask1 & mask2]
-            flatten_data[key] = new_array
+
     return flatten_data
 
 

--- a/src/test/spreadsheet_to_cas_test.py
+++ b/src/test/spreadsheet_to_cas_test.py
@@ -241,9 +241,9 @@ class TestYourModule(unittest.TestCase):
         self.assertEqual(result_empty, {})
 
         # Test with a non-empty list
-        input_list = ['item1', 'item2', 'item3']
+        input_list = ["item1", "item2", "item3"]
         result_non_empty = calculate_labelset_rank(input_list)
-        expected_result_non_empty = {'item1': 0, 'item2': 1, 'item3': 2}
+        expected_result_non_empty = {"item1": 0, "item2": 1, "item3": 2}
         self.assertEqual(result_non_empty, expected_result_non_empty)
 
     @patch("cellxgene_census.download_source_h5ad", return_value=None)
@@ -251,7 +251,9 @@ class TestYourModule(unittest.TestCase):
         "cas.spreadsheet_to_cas.read_anndata_file", return_value=generate_mock_dataset()
     )
     def test_spreadsheet2cas(self, mock_read_anndata_file, mock_download_source_h5ad):
-        spreadsheet2cas("test_data/sample_spreadsheet_data.xlsx", None, None, None, "output.json")
+        spreadsheet2cas(
+            "test_data/sample_spreadsheet_data.xlsx", None, None, None, "output.json"
+        )
 
         json_file_path = "output.json"
 


### PR DESCRIPTION
Fixes #35 

This PR replaces the usage of anndata library operations with direct interactions using the h5py API. Previously, the code relied on anndata library for handling operations related to AnnData objects. However, to improve efficiency and flexibility, we have transitioned to directly using the h5py library, which provides more low-level access to HDF5 files.