### PR TITLE
TDT related fixes

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,0 +1,31 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9']
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+
+      - name: Run test
+        run: PYTHONPATH=./src:$PYTHONPATH python -m unittest discover -s src -p '*_test.py'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="cas-tools",
-    version="0.0.1.dev24",
+    version="0.0.1.dev25",
     description="Cell Annotation Schema tools.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="cas-tools",
-    version="0.0.1.dev23",
+    version="0.0.1.dev24",
     description="Cell Annotation Schema tools.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="cas-tools",
-    version="0.0.1.dev22",
+    version="0.0.1.dev23",
     description="Cell Annotation Schema tools.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/src/cas/flatten_data_to_tables.py
+++ b/src/cas/flatten_data_to_tables.py
@@ -102,14 +102,15 @@ def generate_metadata_table(cta, file_name_prefix, project_config, out_folder):
     records = list()
 
     record = dict()
-    record["cellannotation_schema_version"] = cta.get(
-        "cellannotation_schema_version", ""
-    )
+    record["index"] = "1"
     record["author_name"] = cta.get("author_name", "")
     record["author_contact"] = cta.get("author_contact", "")
     record["orcid"] = project_config.get("author", "")
     record["author_list"] = cta.get("author_list", "")
     record["matrix_file_id"] = project_config.get("matrix_file_id", "")
+    record["cellannotation_schema_version"] = cta.get(
+        "cellannotation_schema_version", ""
+    )
     record["cellannotation_timestamp"] = cta.get("cellannotation_timestamp", "")
     record["cellannotation_version"] = cta.get("cellannotation_version", "")
     record["cellannotation_url"] = cta.get("cellannotation_url", "")

--- a/src/cas/flatten_data_to_tables.py
+++ b/src/cas/flatten_data_to_tables.py
@@ -278,9 +278,9 @@ def list_to_string(my_list: list):
         string representation of the list
     """
     if not my_list:
-        str_value = "[]"
+        str_value = ""
     else:
-        str_value = str(my_list).replace("'", '"')
+        str_value = "|".join(my_list)
     return str_value
 
 
@@ -322,4 +322,4 @@ def normalize_column_name(column_name: str) -> str:
     Returns:
         normalized column_name
     """
-    return column_name.strip().replace("(", "_").replace(")", "_")
+    return column_name.strip().replace("(", "_").replace(")", "_").replace("-", "_")

--- a/src/cas/flatten_data_to_tables.py
+++ b/src/cas/flatten_data_to_tables.py
@@ -6,7 +6,7 @@ import pandas as pd
 from cas.accession.incremental_accession_manager import IncrementalAccessionManager
 
 
-def serialize_to_tables(cta, file_name_prefix, out_folder, accession_prefix):
+def serialize_to_tables(cta, file_name_prefix, out_folder, project_config):
     """
     Writes cell type annotation object to a series of tsv files.
     Tables to generate:
@@ -19,13 +19,14 @@ def serialize_to_tables(cta, file_name_prefix, out_folder, accession_prefix):
         cta: cell type annotation object to serialize.
         file_name_prefix: Name prefix for table names
         out_folder: output folder path.
-        accession_prefix: accession id prefix
+        project_config: project configuration with extra metadata
     """
+    accession_prefix = project_config["accession_id_prefix"]
     annotation_table_path = generate_annotation_table(
         accession_prefix, cta, file_name_prefix, out_folder
     )
     labelset_table_path = generate_labelset_table(cta, file_name_prefix, out_folder)
-    metadata_table_path = generate_metadata_table(cta, file_name_prefix, out_folder)
+    metadata_table_path = generate_metadata_table(cta, file_name_prefix, project_config, out_folder)
     annotation_transfer_table_path = generate_annotation_transfer_table(
         cta, file_name_prefix, out_folder
     )
@@ -85,13 +86,14 @@ def generate_annotation_transfer_table(cta, file_name_prefix, out_folder):
     return table_path
 
 
-def generate_metadata_table(cta, file_name_prefix, out_folder):
+def generate_metadata_table(cta, file_name_prefix, project_config, out_folder):
     """
     Generates the metadata table.
 
     Parameters:
         cta: cell type annotation object to serialize.
         file_name_prefix: Name prefix for table names
+        project_config: metadata coming from project config
         out_folder: output folder path.
     """
     table_path = os.path.join(out_folder, file_name_prefix + "_metadata.tsv")
@@ -103,12 +105,14 @@ def generate_metadata_table(cta, file_name_prefix, out_folder):
     record["cellannotation_schema_version"] = cta.get(
         "cellannotation_schema_version", ""
     )
+    record["author_name"] = cta.get("author_name", "")
+    record["author_contact"] = cta.get("author_contact", "")
+    record["orcid"] = project_config.get("author", "")
+    record["author_list"] = cta.get("author_list", "")
+    record["matrix_file_id"] = project_config.get("matrix_file_id", "")
     record["cellannotation_timestamp"] = cta.get("cellannotation_timestamp", "")
     record["cellannotation_version"] = cta.get("cellannotation_version", "")
     record["cellannotation_url"] = cta.get("cellannotation_url", "")
-    record["author_name"] = cta.get("author_name", "")
-    record["author_contact"] = cta.get("author_contact", "")
-    record["orcid"] = cta.get("orcid", "")
     records.append(record)
 
     records_df = pd.DataFrame.from_records(records)

--- a/src/cas/ingest/ingest_user_table.py
+++ b/src/cas/ingest/ingest_user_table.py
@@ -1,4 +1,6 @@
 import os
+import pkg_resources
+
 from pathlib import Path
 from typing import get_type_hints
 
@@ -60,6 +62,7 @@ def ingest_user_data(data_file: str, config_file: str):
     if not is_config_valid:
         raise Exception("Configuration file is not valid!")
     cas = CellTypeAnnotation(config["author_name"], list())
+    cas.cellannotation_schema_version = pkg_resources.get_distribution("cell-annotation-schema").version
     headers, records = read_tsv_to_dict(data_file, generated_ids=True)
     config_fields = config["fields"]
     populate_labelsets(cas, config_fields)

--- a/src/cas/model.py
+++ b/src/cas/model.py
@@ -183,6 +183,11 @@ class CellTypeAnnotation(EncoderMixin):
     and provenance. As this is intended as a general schema, compulsory fields are kept to a minimum. However, tools 
     using this schema are encouarged to specify a larger set of compulsory fields for publication."""
 
+    matrix_file_id: Optional[str] = None
+    """A resolvable ID for a cell by gene matrix file in the form namespace:accession, e.g. 
+    CellXGene_dataset:8e10f1c4-8e98-41e5-b65f-8cd89a887122. Please see https://github.com/cellannotation/cell-annotation
+    -schema/registry/registry.json for supported namespaces."""
+
     labelsets: Optional[List[Labelset]] = None
 
     author_contact: Optional[str] = None
@@ -196,12 +201,20 @@ class CellTypeAnnotation(EncoderMixin):
     This versioning MUST follow the format `'[MAJOR].[MINOR].[PATCH]'` as defined by Semantic Versioning 2.0.0, 
     https://semver.org/"""
 
+    cellannotation_timestamp: Optional[str] = None
+    """The timestamp of all cell annotations published (per dataset). This MUST be a string in the format 
+    '%yyyy-%mm-%dd %hh:%mm:%ss'."""
+
     cellannotation_version: Optional[str] = None
     """The version for all cell annotations published (per dataset). This MUST be a string. The recommended versioning 
     format is `'[MAJOR].[MINOR].[PATCH]'` as defined by Semantic Versioning 2.0.0, https://semver.org/"""
 
     cellannotation_url: Optional[str] = None
     """A persistent URL of all cell annotations published (per dataset)."""
+
+    author_list: Optional[List[str]] = None
+    """This field stores a list of users who are included in the project as collaborators, regardless of their specific 
+    role. An example list; John Smith|Cody Miller|Sarah Jones."""
 
     def add_annotation_object(self, obj):
         """

--- a/src/test/flatten_data_to_tables_test.py
+++ b/src/test/flatten_data_to_tables_test.py
@@ -41,7 +41,7 @@ class TabularSerialisationTests(unittest.TestCase):
 
     def test_annotation_table(self):
         cta = ingest_user_data(RAW_DATA, TEST_CONFIG)
-        tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, "TST_")
+        tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, {"accession_id_prefix": "TST_"})
 
         annotation_table_path = os.path.join(OUT_FOLDER, "Test_table_annotation.tsv")
         self.assertEqual(annotation_table_path, tables[0])
@@ -57,7 +57,7 @@ class TabularSerialisationTests(unittest.TestCase):
         self.assertEqual("TST_300", cluster_1["parent_cell_set_accession"])
         self.assertEqual("D1-Matrix", cluster_1["parent_cell_set_name"])
         self.assertEqual("cluster", cluster_1["labelset"])
-        self.assertEqual('["EPYC", "RELN", "GULP1"]', cluster_1["marker_gene_evidence"])
+        self.assertEqual('EPYC|RELN|GULP1', cluster_1["marker_gene_evidence"])
         self.assertEqual("PuR(0.52) | CaH(0.39)", cluster_1["region.info _Frequency_"])
         # self.assertEqual("", cluster_1["cell_ids"])
 
@@ -81,7 +81,7 @@ class TabularSerialisationTests(unittest.TestCase):
 
     def test_labelset_table(self):
         cta = ingest_user_data(RAW_DATA, TEST_CONFIG)
-        tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, "TST_")
+        tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, {"accession_id_prefix": "TST_"})
 
         table_path = os.path.join(OUT_FOLDER, "Test_table_labelset.tsv")
         self.assertEqual(table_path, tables[1])
@@ -103,7 +103,7 @@ class TabularSerialisationTests(unittest.TestCase):
 
     def test_metadata_table(self):
         cta = ingest_user_data(RAW_DATA, TEST_CONFIG)
-        tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, "TST_")
+        tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, {"accession_id_prefix": "TST_"})
 
         table_path = os.path.join(OUT_FOLDER, "Test_table_metadata.tsv")
         self.assertEqual(table_path, tables[2])
@@ -115,12 +115,12 @@ class TabularSerialisationTests(unittest.TestCase):
         self.assertEqual(1, len(records))
 
         self.assertEqual("Test User", records[1]["author_name"])
-        self.assertEqual("", records[1]["cellannotation_schema_version"])
+        self.assertTrue("." in records[1]["cellannotation_schema_version"])
         self.assertEqual("", records[1]["cellannotation_version"])
 
     def test_annotation_transfer_table(self):
         cta = ingest_user_data(RAW_DATA, TEST_CONFIG)
-        tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, "TST_")
+        tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, {"accession_id_prefix": "TST_"})
 
         table_path = os.path.join(OUT_FOLDER, "Test_table_annotation_transfer.tsv")
         self.assertEqual(table_path, tables[3])
@@ -138,7 +138,7 @@ class TabularSerialisationTests(unittest.TestCase):
 
     def test_loading_from_json(self):
         cta = read_cas_json_file(TEST_JSON)
-        tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, "CS202210140_")
+        tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, {"accession_id_prefix": "CS202210140_"})
 
         annotation_table_path = os.path.join(OUT_FOLDER, "Test_table_annotation.tsv")
         self.assertEqual(annotation_table_path, tables[0])

--- a/src/test/ingest_user_table_test.py
+++ b/src/test/ingest_user_table_test.py
@@ -34,6 +34,9 @@ class CellTypeAnnotationTests(unittest.TestCase):
         self.assertTrue("author_name" in result)
         self.assertEqual("Test User", result["author_name"])
 
+        self.assertTrue("cellannotation_schema_version" in result)
+        self.assertTrue("." in result["cellannotation_schema_version"])
+
         self.assertTrue("labelsets" in result)
         self.assertEqual(4, len(result["labelsets"]))
         # print(result["labelsets"])

--- a/src/test/reports_test.py
+++ b/src/test/reports_test.py
@@ -41,7 +41,7 @@ class ReportsTests(unittest.TestCase):
 
         df = cas.get_all_annotations(
             labels=[
-                ("Supercluster", "Microglia"),
+                ("supercluster_term", "Microglia"),
                 ("Cluster", "Mgl_4"),
                 ("Cluster", "Astro_55"),
                 ("Dummy", "Dummy"),

--- a/src/test/spreadsheet_to_cas_test.py
+++ b/src/test/spreadsheet_to_cas_test.py
@@ -17,6 +17,8 @@ from cas.spreadsheet_to_cas import (
 
 warnings.filterwarnings("ignore", category=UserWarning, module="anndata._core.anndata")
 
+TEST_SPREADSHEET = os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_data/sample_spreadsheet_data.xlsx")
+
 
 def generate_mock_dataset():
     # Mock AnnData dataset for testing
@@ -190,7 +192,7 @@ class SpreadsheetToCasTests(unittest.TestCase):
     def test_read_spreadsheet_default_sheet(self):
         # Test reading spreadsheet with default sheet
         meta_data, column_names, raw_data = read_spreadsheet(
-            "test_data/sample_spreadsheet_data.xlsx", None
+            TEST_SPREADSHEET, None
         )
         self.assertEqual(len(meta_data), 8)
         self.assertEqual(len(column_names), 9)
@@ -199,7 +201,7 @@ class SpreadsheetToCasTests(unittest.TestCase):
     def test_read_spreadsheet_custom_sheet(self):
         # Test reading spreadsheet with custom sheet
         meta_data, column_names, raw_data = read_spreadsheet(
-            "test_data/sample_spreadsheets_data.xlsx",
+            TEST_SPREADSHEET,
             sheet_name="PBMC3_Yoshida_2022_PBMC",
         )
         self.assertEqual(len(meta_data), 8)
@@ -238,7 +240,7 @@ class SpreadsheetToCasTests(unittest.TestCase):
         "cas.spreadsheet_to_cas.read_anndata_file", return_value=generate_mock_dataset()
     )
     def test_spreadsheet2cas(self, mock_read_anndata_file, mock_download_source_h5ad):
-        spreadsheet2cas("test_data/sample_spreadsheet_data.xlsx", None, None, None, "output.json")
+        spreadsheet2cas(TEST_SPREADSHEET, None, None, None, "output.json")
 
         json_file_path = "output.json"
 


### PR DESCRIPTION
Table flattening logic updated:
- list serialisation changed from json list format to a `|` separated format.
- Metadata columns updated
- `cellannotation_schema_version` value is read from `cell-annotation-schema` library version

Unit tests fixed, they weren't running previously.
Unit tests runner GitHub action added, test data path issues solved in some tests.