### PR TITLE
Anndata to cas single child bug

### DIFF
--- a/src/cas/anndata_to_cas.py
+++ b/src/cas/anndata_to_cas.py
@@ -93,7 +93,7 @@ def add_parent_cell_hierarchy(cas: Dict[str, Any], parent_cell_look_up: Dict[str
             update_parent_info(value, inner_key, inner_value)
         elif value["cell_ids"] == inner_value["cell_ids"]:
             if int(inner_value["rank"]) < int(value["rank"]):
-                update_parent_info(value, key, value)
+                update_parent_info(inner_value, key, value)
             elif int(value["rank"]) < int(inner_value["rank"]):
                 update_parent_info(value, inner_key, inner_value)
 

--- a/src/cas/anndata_to_cas.py
+++ b/src/cas/anndata_to_cas.py
@@ -96,6 +96,11 @@ def add_parent_cell_hierarchy(cas: Dict[str, Any], parent_cell_look_up: Dict[str
                 update_parent_info(inner_value, key, value)
             elif int(value["rank"]) < int(inner_value["rank"]):
                 update_parent_info(value, inner_key, inner_value)
+            else:
+                raise ValueError(
+                    f"{key} and {inner_key} cell labels have the same cell_ids. cell_ids can't be identical at "
+                    f"the same rank."
+                )
 
     annotation_list = cas.get("annotations")
     for annotation in annotation_list:

--- a/src/cas/anndata_to_cas.py
+++ b/src/cas/anndata_to_cas.py
@@ -1,13 +1,13 @@
-import json
 import itertools
-from typing import Any, List, Dict
+import json
+from typing import Any, Dict, List
 
 import anndata as ad
 import pandas as pd
 
+from cas.accession.hash_accession_manager import HashAccessionManager
 from cas.file_utils import read_anndata_file
 from cas.spreadsheet_to_cas import calculate_labelset_rank, get_cell_ids
-from cas.accession.hash_accession_manager import HashAccessionManager
 
 
 def anndata2cas(
@@ -46,7 +46,9 @@ def anndata2cas(
         json.dump(cas, json_file, indent=2)
 
 
-def update_parent_info(value: Dict[str, Any], parent_key: str, parent_value: Dict[str, Any]):
+def update_parent_info(
+    value: Dict[str, Any], parent_key: str, parent_value: Dict[str, Any]
+):
     """Updates parent information in a child item's dictionary.
 
     Args:
@@ -57,11 +59,13 @@ def update_parent_info(value: Dict[str, Any], parent_key: str, parent_value: Dic
     This function modifies `value` to include `parent` (using `parent_key`),
     `p_accession`, and `parent_rank` based on `parent_value`.
     """
-    value.update({
-        "parent": parent_key,
-        "p_accession": parent_value.get("accession"),
-        "parent_rank": parent_value.get("rank"),
-    })
+    value.update(
+        {
+            "parent": parent_key,
+            "p_accession": parent_value.get("accession"),
+            "parent_rank": parent_value.get("rank"),
+        }
+    )
 
 
 def add_parent_cell_hierarchy(cas: Dict[str, Any], parent_cell_look_up: Dict[str, Any]):
@@ -75,11 +79,17 @@ def add_parent_cell_hierarchy(cas: Dict[str, Any], parent_cell_look_up: Dict[str
     Returns:
         None
     """
-    for (key, value), (inner_key, inner_value) in itertools.combinations(parent_cell_look_up.items(), 2):
-        if value.get("parent") is not None and value.get("parent_rank", 0) <= inner_value.get("rank"):
+    for (key, value), (inner_key, inner_value) in itertools.combinations(
+        parent_cell_look_up.items(), 2
+    ):
+        if value.get("parent") is not None and value.get(
+            "parent_rank", 0
+        ) <= inner_value.get("rank"):
             continue
 
-        if value["cell_ids"] != inner_value["cell_ids"] and value["cell_ids"].issubset(inner_value["cell_ids"]):
+        if value["cell_ids"] != inner_value["cell_ids"] and value["cell_ids"].issubset(
+            inner_value["cell_ids"]
+        ):
             update_parent_info(value, inner_key, inner_value)
         elif value["cell_ids"] == inner_value["cell_ids"]:
             if int(inner_value["rank"]) < int(value["rank"]):

--- a/src/test/anndata_to_cas_test.py
+++ b/src/test/anndata_to_cas_test.py
@@ -1,13 +1,18 @@
+from typing import Any, Dict
 import unittest
+
+import pandas as pd
+import anndata as ad
+
 from cas.anndata_to_cas import (
     generate_cas_annotations,
     generate_cas_labelsets,
     generate_cas_metadata,
     calculate_labelset,
+    calculate_labelset_rank,
     add_parent_cell_hierarchy,
+    update_parent_info,
 )
-from cas.file_utils import read_anndata_file
-import pandas as pd
 
 
 class TestAnndataToCas(unittest.TestCase):
@@ -23,28 +28,30 @@ class TestAnndataToCas(unittest.TestCase):
         )
         self.uns = {"schema_version": "1.0"}
 
-    def test_generate_cas_annotations(self):
-        cas = generate_cas_metadata(self.uns)
-
-        # Ensure CAS annotations are added correctly
-        self.assertIn("annotations", cas)
-
     def test_generate_cas_labelsets(self):
         cas = {"labelsets": []}
-        labelsets = ["labelset1", "labelset2"]
-        generate_cas_labelsets(cas, labelsets)
+        labelset_dict = {
+            "labelset1": {"members": {"member1", "member2", "member3"}, "rank": 0},
+            "labelset2": {"members": {"member4", "member5"}, "rank": 1},
+            "labelset3": {"members": {"member6", "member7", "member8", "member9"}, "rank": 2},
+        }
+        generate_cas_labelsets(cas, labelset_dict)
 
         # Ensure labelsets are added correctly
         self.assertIn("labelsets", cas)
-        self.assertEqual(len(cas["labelsets"]), 2)
+        self.assertEqual(len(cas["labelsets"]), 3)
         self.assertEqual(cas["labelsets"][0]["name"], "labelset1")
         self.assertEqual(cas["labelsets"][1]["name"], "labelset2")
+        self.assertEqual(cas["labelsets"][2]["name"], "labelset3")
+        self.assertEqual(cas["labelsets"][0]["rank"], "0")
+        self.assertEqual(cas["labelsets"][1]["rank"], "1")
+        self.assertEqual(cas["labelsets"][2]["rank"], "2")
 
     def test_generate_cas_metadata(self):
         cas = generate_cas_metadata(self.uns)
 
-        # Ensure metadata is generated correctly
         self.assertEqual(cas["cellannotation_schema_version"], "1.0")
+        self.assertIn("annotations", cas)
 
     def test_calculate_labelset(self):
         labelsets = ["labelset1", "labelset2"]
@@ -53,8 +60,36 @@ class TestAnndataToCas(unittest.TestCase):
         # Ensure labelset dictionary is calculated correctly
         self.assertIn("labelset1", labelset_dict)
         self.assertIn("labelset2", labelset_dict)
-        self.assertEqual(labelset_dict["labelset1"], {"A", "B", "C"})
-        self.assertEqual(labelset_dict["labelset2"], {"X", "Y"})
+        self.assertEqual(labelset_dict["labelset1"], {"members": {"A", "B", "C"}, "rank": "0"})
+        self.assertEqual(labelset_dict["labelset2"], {"members": {"X", "Y"}, "rank": "1"})
+
+    def test_generate_cas_annotations(self):
+        example_data = pd.DataFrame({
+            'feature1': [1, 2],
+            'feature2': [3, 4]
+        })
+        obs_data = pd.DataFrame({
+            'cell_type': ['type1', 'type2'],
+            'cell_type_ontology_term_id': ['CTO:0001', 'CTO:0002'],
+            'labelset1': ['label1', 'label2']
+        }, index=['sample1', 'sample2'])
+
+        adata = ad.AnnData(X=example_data.values, obs=obs_data)
+
+        cas = {'annotations': []}
+        include_hierarchy = True
+        labelset_dict = {
+            'labelset1': {
+                'members': {'label1', 'label2'},
+                'rank': 1
+            }
+        }
+
+        result = generate_cas_annotations(adata, cas, include_hierarchy, labelset_dict)
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("label1", result)
+        self.assertIn("label2", result)
 
     def test_add_parent_cell_hierarchy(self):
         cas = {
@@ -64,10 +99,30 @@ class TestAnndataToCas(unittest.TestCase):
         }
         parent_cell_look_up = {"A": {"cell_ids": {1, 2}, "accession": "A_123", "parent": "P", "p_accession": "P_123"}}
 
-        add_parent_cell_hierarchy(cas, include_hierarchy=True, parent_cell_look_up=parent_cell_look_up)
+        add_parent_cell_hierarchy(cas, parent_cell_look_up=parent_cell_look_up)
 
         # Ensure parent cell hierarchy information is added correctly
         self.assertIn("annotations", cas)
         for annotation in cas["annotations"]:
             self.assertIn("parent_cell_set_name", annotation)
             self.assertIn("parent_cell_set_accession", annotation)
+
+    def test_update_parent_info(self):
+        """Test updating child item with correct parent information."""
+        # Setup initial child and parent dictionaries
+        child = {"name": "child1", "parent": None, "p_accession": None, "parent_rank": None}
+        parent = {"name": "parent1", "accession": "A001", "rank": 1}
+
+        # Expected result after updating child with parent info
+        expected = {"name": "child1", "parent": "parent1", "p_accession": "A001", "parent_rank": 1}
+
+        # Update child with parent info
+        update_parent_info(child, "parent1", parent)
+
+        # Assert that child dictionary is updated correctly
+        self.assertEqual(child, expected)
+
+    def test_calculate_labelset_rank(self):
+        input_list = ["label1", "label2", "label3"]
+        expected_result = {"label1": 0, "label2": 1, "label3": 2}
+        self.assertEqual(calculate_labelset_rank(input_list), expected_result)

--- a/src/test/anndata_to_cas_test.py
+++ b/src/test/anndata_to_cas_test.py
@@ -1,16 +1,16 @@
-from typing import Any, Dict
 import unittest
+from typing import Any, Dict
 
-import pandas as pd
 import anndata as ad
+import pandas as pd
 
 from cas.anndata_to_cas import (
+    add_parent_cell_hierarchy,
+    calculate_labelset,
+    calculate_labelset_rank,
     generate_cas_annotations,
     generate_cas_labelsets,
     generate_cas_metadata,
-    calculate_labelset,
-    calculate_labelset_rank,
-    add_parent_cell_hierarchy,
     update_parent_info,
 )
 
@@ -33,7 +33,10 @@ class TestAnndataToCas(unittest.TestCase):
         labelset_dict = {
             "labelset1": {"members": {"member1", "member2", "member3"}, "rank": 0},
             "labelset2": {"members": {"member4", "member5"}, "rank": 1},
-            "labelset3": {"members": {"member6", "member7", "member8", "member9"}, "rank": 2},
+            "labelset3": {
+                "members": {"member6", "member7", "member8", "member9"},
+                "rank": 2,
+            },
         }
         generate_cas_labelsets(cas, labelset_dict)
 
@@ -60,30 +63,29 @@ class TestAnndataToCas(unittest.TestCase):
         # Ensure labelset dictionary is calculated correctly
         self.assertIn("labelset1", labelset_dict)
         self.assertIn("labelset2", labelset_dict)
-        self.assertEqual(labelset_dict["labelset1"], {"members": {"A", "B", "C"}, "rank": "0"})
-        self.assertEqual(labelset_dict["labelset2"], {"members": {"X", "Y"}, "rank": "1"})
+        self.assertEqual(
+            labelset_dict["labelset1"], {"members": {"A", "B", "C"}, "rank": "0"}
+        )
+        self.assertEqual(
+            labelset_dict["labelset2"], {"members": {"X", "Y"}, "rank": "1"}
+        )
 
     def test_generate_cas_annotations(self):
-        example_data = pd.DataFrame({
-            'feature1': [1, 2],
-            'feature2': [3, 4]
-        })
-        obs_data = pd.DataFrame({
-            'cell_type': ['type1', 'type2'],
-            'cell_type_ontology_term_id': ['CTO:0001', 'CTO:0002'],
-            'labelset1': ['label1', 'label2']
-        }, index=['sample1', 'sample2'])
+        example_data = pd.DataFrame({"feature1": [1, 2], "feature2": [3, 4]})
+        obs_data = pd.DataFrame(
+            {
+                "cell_type": ["type1", "type2"],
+                "cell_type_ontology_term_id": ["CTO:0001", "CTO:0002"],
+                "labelset1": ["label1", "label2"],
+            },
+            index=["sample1", "sample2"],
+        )
 
         adata = ad.AnnData(X=example_data.values, obs=obs_data)
 
-        cas = {'annotations': []}
+        cas = {"annotations": []}
         include_hierarchy = True
-        labelset_dict = {
-            'labelset1': {
-                'members': {'label1', 'label2'},
-                'rank': 1
-            }
-        }
+        labelset_dict = {"labelset1": {"members": {"label1", "label2"}, "rank": 1}}
 
         result = generate_cas_annotations(adata, cas, include_hierarchy, labelset_dict)
 
@@ -97,7 +99,14 @@ class TestAnndataToCas(unittest.TestCase):
                 {"cell_label": "A"},
             ]
         }
-        parent_cell_look_up = {"A": {"cell_ids": {1, 2}, "accession": "A_123", "parent": "P", "p_accession": "P_123"}}
+        parent_cell_look_up = {
+            "A": {
+                "cell_ids": {1, 2},
+                "accession": "A_123",
+                "parent": "P",
+                "p_accession": "P_123",
+            }
+        }
 
         add_parent_cell_hierarchy(cas, parent_cell_look_up=parent_cell_look_up)
 
@@ -110,11 +119,21 @@ class TestAnndataToCas(unittest.TestCase):
     def test_update_parent_info(self):
         """Test updating child item with correct parent information."""
         # Setup initial child and parent dictionaries
-        child = {"name": "child1", "parent": None, "p_accession": None, "parent_rank": None}
+        child = {
+            "name": "child1",
+            "parent": None,
+            "p_accession": None,
+            "parent_rank": None,
+        }
         parent = {"name": "parent1", "accession": "A001", "rank": 1}
 
         # Expected result after updating child with parent info
-        expected = {"name": "child1", "parent": "parent1", "p_accession": "A001", "parent_rank": 1}
+        expected = {
+            "name": "child1",
+            "parent": "parent1",
+            "p_accession": "A001",
+            "parent_rank": 1,
+        }
 
         # Update child with parent info
         update_parent_info(child, "parent1", parent)


### PR DESCRIPTION
Fixes #45 

Refactored parent adding logic. It now support parent and the child having the same set of cell ids. And, it also correctly handles A -> B -> C relationships