### PR TITLE
Tabular flattening table names simplified

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="cas-tools",
-    version="0.0.1.dev26",
+    version="0.0.1.dev28",
     description="Cell Annotation Schema tools.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/src/cas/flatten_data_to_tables.py
+++ b/src/cas/flatten_data_to_tables.py
@@ -22,14 +22,10 @@ def serialize_to_tables(cta, file_name_prefix, out_folder, project_config):
         project_config: project configuration with extra metadata
     """
     accession_prefix = project_config["accession_id_prefix"]
-    annotation_table_path = generate_annotation_table(
-        accession_prefix, cta, file_name_prefix, out_folder
-    )
-    labelset_table_path = generate_labelset_table(cta, file_name_prefix, out_folder)
-    metadata_table_path = generate_metadata_table(cta, file_name_prefix, project_config, out_folder)
-    annotation_transfer_table_path = generate_annotation_transfer_table(
-        cta, file_name_prefix, out_folder
-    )
+    annotation_table_path = generate_annotation_table(accession_prefix, cta, out_folder)
+    labelset_table_path = generate_labelset_table(cta, out_folder)
+    metadata_table_path = generate_metadata_table(cta, project_config, out_folder)
+    annotation_transfer_table_path = generate_annotation_transfer_table(cta, out_folder)
     return [
         annotation_table_path,
         labelset_table_path,
@@ -38,16 +34,15 @@ def serialize_to_tables(cta, file_name_prefix, out_folder, project_config):
     ]
 
 
-def generate_annotation_transfer_table(cta, file_name_prefix, out_folder):
+def generate_annotation_transfer_table(cta, out_folder):
     """
     Generates annotation transfer table.
 
     Parameters:
         cta: cell type annotation object to serialize.
-        file_name_prefix: Name prefix for table names
         out_folder: output folder path.
     """
-    table_path = os.path.join(out_folder, file_name_prefix + "_annotation_transfer.tsv")
+    table_path = os.path.join(out_folder, "annotation_transfer.tsv")
 
     cta = asdict(cta)
     records = list()
@@ -86,17 +81,16 @@ def generate_annotation_transfer_table(cta, file_name_prefix, out_folder):
     return table_path
 
 
-def generate_metadata_table(cta, file_name_prefix, project_config, out_folder):
+def generate_metadata_table(cta, project_config, out_folder):
     """
     Generates the metadata table.
 
     Parameters:
         cta: cell type annotation object to serialize.
-        file_name_prefix: Name prefix for table names
         project_config: metadata coming from project config
         out_folder: output folder path.
     """
-    table_path = os.path.join(out_folder, file_name_prefix + "_metadata.tsv")
+    table_path = os.path.join(out_folder, "metadata.tsv")
 
     cta = asdict(cta)
     records = list()
@@ -121,16 +115,15 @@ def generate_metadata_table(cta, file_name_prefix, project_config, out_folder):
     return table_path
 
 
-def generate_labelset_table(cta, file_name_prefix, out_folder):
+def generate_labelset_table(cta, out_folder):
     """
     Generates labelset table.
 
     Parameters:
         cta: cell type annotation object to serialize.
-        file_name_prefix: Name prefix for table names
         out_folder: output folder path.
     """
-    table_path = os.path.join(out_folder, file_name_prefix + "_labelset.tsv")
+    table_path = os.path.join(out_folder + "labelset.tsv")
 
     cta = asdict(cta)
     records = list()
@@ -167,17 +160,16 @@ def generate_labelset_table(cta, file_name_prefix, out_folder):
     return table_path
 
 
-def generate_annotation_table(accession_prefix, cta, file_name_prefix, out_folder):
+def generate_annotation_table(accession_prefix, cta, out_folder):
     """
     Generates annotation table.
 
     Parameters:
         cta: cell type annotation object to serialize.
-        file_name_prefix: Name prefix for table names
         out_folder: output folder path.
         accession_prefix: accession id prefix
     """
-    std_data_path = os.path.join(out_folder, file_name_prefix + "_annotation.tsv")
+    std_data_path = os.path.join(out_folder, "annotation.tsv")
     accession_manager = IncrementalAccessionManager(accession_prefix)
 
     cta = asdict(cta)

--- a/src/test/flatten_data_to_tables_test.py
+++ b/src/test/flatten_data_to_tables_test.py
@@ -44,7 +44,7 @@ class TabularSerialisationTests(unittest.TestCase):
         cta = ingest_user_data(RAW_DATA, TEST_CONFIG)
         tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, {"accession_id_prefix": "TST_"})
 
-        annotation_table_path = os.path.join(OUT_FOLDER, "Test_table_annotation.tsv")
+        annotation_table_path = os.path.join(OUT_FOLDER, "annotation.tsv")
         self.assertEqual(annotation_table_path, tables[0])
         self.assertTrue(os.path.isfile(annotation_table_path))
 
@@ -84,7 +84,7 @@ class TabularSerialisationTests(unittest.TestCase):
         cta = ingest_user_data(RAW_DATA, TEST_CONFIG)
         tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, {"accession_id_prefix": "TST_"})
 
-        table_path = os.path.join(OUT_FOLDER, "Test_table_labelset.tsv")
+        table_path = os.path.join(OUT_FOLDER, "labelset.tsv")
         self.assertEqual(table_path, tables[1])
         self.assertTrue(os.path.isfile(table_path))
 
@@ -106,7 +106,7 @@ class TabularSerialisationTests(unittest.TestCase):
         cta = ingest_user_data(RAW_DATA, TEST_CONFIG)
         tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, {"accession_id_prefix": "TST_"})
 
-        table_path = os.path.join(OUT_FOLDER, "Test_table_metadata.tsv")
+        table_path = os.path.join(OUT_FOLDER, "metadata.tsv")
         self.assertEqual(table_path, tables[2])
         self.assertTrue(os.path.isfile(table_path))
 
@@ -123,7 +123,7 @@ class TabularSerialisationTests(unittest.TestCase):
         cta = ingest_user_data(RAW_DATA, TEST_CONFIG)
         tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, {"accession_id_prefix": "TST_"})
 
-        table_path = os.path.join(OUT_FOLDER, "Test_table_annotation_transfer.tsv")
+        table_path = os.path.join(OUT_FOLDER, "annotation_transfer.tsv")
         self.assertEqual(table_path, tables[3])
         self.assertTrue(os.path.isfile(table_path))
 
@@ -141,7 +141,7 @@ class TabularSerialisationTests(unittest.TestCase):
         cta = read_cas_json_file(TEST_JSON)
         tables = serialize_to_tables(cta, "Test_table", OUT_FOLDER, {"accession_id_prefix": "CS202210140_"})
 
-        annotation_table_path = os.path.join(OUT_FOLDER, "Test_table_annotation.tsv")
+        annotation_table_path = os.path.join(OUT_FOLDER, "annotation.tsv")
         self.assertEqual(annotation_table_path, tables[0])
         self.assertTrue(os.path.isfile(annotation_table_path))
 


### PR DESCRIPTION
Related with https://github.com/brain-bican/taxonomy-development-tools/issues/106

Previously table names was getting user table name as prefix (like **AIT115_annotation_sheet_**annotation.tsv) now standard table names simplified to `annotation.tsv`, `labelset.tsv`, `metadata.tsv` and `annotation_transfer.tsv`