### PR TITLE
Cell set accession bug fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="cas-tools",
-    version="0.0.1.dev46",
+    version="0.0.1.dev48",
     description="Cell Annotation Schema tools.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/src/cas/anndata_to_cas.py
+++ b/src/cas/anndata_to_cas.py
@@ -126,12 +126,12 @@ def add_annotations_to_cas(
                 "labelset": labelset,
                 "cell_label": label,
                 "cell_fullname": label,
-                "cell_set_accession": parent_cell_look_up[label]["accession"],
-                "cell_ontology_term_id": parent_cell_look_up[label][
+                "cell_set_accession": parent_cell_look_up[f"{labelset}:{label}"]["accession"],
+                "cell_ontology_term_id": parent_cell_look_up[f"{labelset}:{label}"][
                     "cell_ontology_term_id"
                 ],
-                "cell_ontology_term": parent_cell_look_up[label]["cell_ontology_term"],
-                "cell_ids": list(parent_cell_look_up[label]["cell_ids"]),
+                "cell_ontology_term": parent_cell_look_up[f"{labelset}:{label}"]["cell_ontology_term"],
+                "cell_ids": list(parent_cell_look_up[f"{labelset}:{label}"]["cell_ids"]),
                 "rationale": rationale,
                 "rationale_dois": rationale_dois,
                 "marker_gene_evidence": marker_gene_evidence,

--- a/src/cas/spreadsheet_to_cas.py
+++ b/src/cas/spreadsheet_to_cas.py
@@ -214,6 +214,8 @@ def add_annotations_to_cas(cas, raw_data_result, columns, schema, parent_cell_lo
         for column_name in columns:
             if column_name in annotation_properties:
                 anno[column_name] = row[column_name]
+                if column_name == "labelset":
+                    labelset = anno[column_name]
                 if annotation_properties[column_name]["type"] == "array":
                     anno[column_name] = re.split("[,|]", row[column_name])
             elif row[column_name]:
@@ -221,12 +223,12 @@ def add_annotations_to_cas(cas, raw_data_result, columns, schema, parent_cell_lo
 
         anno.update(
             {
-                "cell_ids": list(parent_cell_look_up[label]["cell_ids"]),
-                "cell_set_accession": parent_cell_look_up[label]["accession"],
-                "cell_ontology_term_id": parent_cell_look_up[label][
+                "cell_ids": list(parent_cell_look_up[f"{labelset}:{label}"]["cell_ids"]),
+                "cell_set_accession": parent_cell_look_up[f"{labelset}:{label}"]["accession"],
+                "cell_ontology_term_id": parent_cell_look_up[f"{labelset}:{label}"][
                     "cell_ontology_term_id"
                 ],
-                "cell_ontology_term": parent_cell_look_up[label]["cell_ontology_term"],
+                "cell_ontology_term": parent_cell_look_up[f"{labelset}:{label}"]["cell_ontology_term"],
             }
         )
         if user_annotations:

--- a/src/cas/utils/conversion_utils.py
+++ b/src/cas/utils/conversion_utils.py
@@ -147,9 +147,9 @@ def generate_parent_cell_lookup(anndata, labelset_dict):
             )
 
             if label in parent_cell_look_up:
-                parent_cell_look_up[label]["cell_ids"].update(cell_ids)
+                parent_cell_look_up[f"{k}:{label}"]["cell_ids"].update(cell_ids)
             else:
-                parent_cell_look_up[label] = {
+                parent_cell_look_up[f"{k}:{label}"] = {
                     "cell_ids": set(cell_ids),
                     "accession": cell_set_accession,
                     "rank": v.get("rank"),
@@ -174,7 +174,7 @@ def update_parent_info(
     """
     value.update(
         {
-            "parent": parent_key,
+            "parent": parent_key.split(":")[-1],
             "p_accession": parent_value.get("accession"),
             "parent_rank": parent_value.get("rank"),
         }
@@ -233,7 +233,7 @@ def add_parent_hierarchy_to_annotations(
     """
     annotation_list = cas.get("annotations", [])
     for annotation in annotation_list:
-        parent_info = parent_cell_look_up.get(annotation.get("cell_label"), {})
+        parent_info = parent_cell_look_up.get(f'{annotation.get("labelset")}:{annotation.get("cell_label")}', {})
         parent = parent_info.get("parent")
         p_accession = parent_info.get("p_accession")
         if parent and p_accession:

--- a/src/test/anndata_to_cas_test.py
+++ b/src/test/anndata_to_cas_test.py
@@ -11,7 +11,7 @@ class TestAnndataToCas(unittest.TestCase):
     def setUp(self):
         self.uns = {"schema_version": "1.0"}
         self.parent_cell_look_up = {
-            "A": {
+            "labelset1:A": {
                 "cell_ids": {1, 2},
                 "accession": "A_123",
                 "parent": "P",
@@ -20,7 +20,7 @@ class TestAnndataToCas(unittest.TestCase):
                 "cell_ontology_term_id": "CL:1234567",
                 "cell_ontology_term": "Test cell",
             },
-            "P": {
+            "labelset1:P": {
                 "cell_ids": {1, 2},
                 "accession": "P_123",
                 "rank": 1,

--- a/src/test/conversion_utils_test.py
+++ b/src/test/conversion_utils_test.py
@@ -27,7 +27,7 @@ class TestConversionUtils(unittest.TestCase):
             }
         )
         self.parent_cell_look_up = {
-            "A": {
+            "labelset1:A": {
                 "cell_ids": {1, 2},
                 "accession": "A_123",
                 "parent": "P",
@@ -36,7 +36,7 @@ class TestConversionUtils(unittest.TestCase):
                 "cell_ontology_term_id": "CL:1234567",
                 "cell_ontology_term": "Test cell",
             },
-            "P": {
+            "labelset3:P": {
                 "cell_ids": {1, 2},
                 "accession": "P_123",
                 "rank": 1,
@@ -157,16 +157,17 @@ class TestConversionUtils(unittest.TestCase):
         add_parent_cell_hierarchy(parent_cell_look_up=self.parent_cell_look_up)
 
         # Ensure parent cell hierarchy information is added correctly
-        self.assertIn("parent", self.parent_cell_look_up["A"])
-        self.assertIn("p_accession", self.parent_cell_look_up["A"])
-        self.assertEqual(self.parent_cell_look_up["A"]["parent"], "P")
-        self.assertEqual(self.parent_cell_look_up["A"]["p_accession"], "P_123")
+        self.assertIn("parent", self.parent_cell_look_up["labelset1:A"])
+        self.assertIn("p_accession", self.parent_cell_look_up["labelset1:A"])
+        self.assertEqual(self.parent_cell_look_up["labelset1:A"]["parent"], "P")
+        self.assertEqual(self.parent_cell_look_up["labelset1:A"]["p_accession"], "P_123")
 
     def test_add_parent_hierarchy(self):
         cas = {
             "annotations": [
                 {
                     "cell_label": "A",
+                    "labelset": "labelset1",
                     "cell_ontology_term_id": "CL:1234567",
                     "cell_ontology_term": "Test cell",
                 }
@@ -176,8 +177,11 @@ class TestConversionUtils(unittest.TestCase):
         expected_annotations = [
             {
                 "cell_label": "A",
-                "parent_cell_set_name": "P",
+                "cell_ontology_term": "Test cell",
+                "cell_ontology_term_id": "CL:1234567",
+                "labelset": "labelset1",
                 "parent_cell_set_accession": "P_123",
+                "parent_cell_set_name": "P",
             }
         ]
 

--- a/src/test/spreadsheet_to_cas_test.py
+++ b/src/test/spreadsheet_to_cas_test.py
@@ -226,7 +226,7 @@ class SpreadsheetToCasTests(unittest.TestCase):
 
             self.assertEqual(len(json_data), 9)
             self.assertEqual(len(json_data["annotations"]), 8)
-            self.assertEqual(len(json_data["annotations"][0]), 7)
+            self.assertEqual(len(json_data["annotations"][0]), 9)
             self.assertEqual(len(json_data["labelsets"]), 2)
         finally:
             # Remove the JSON file after the test


### PR DESCRIPTION
Issue:
The issue arises when the same label appears in two different label sets. The lookup dictionary is created based on labels, which causes a conflict.

Details:
Both the `type EEC` and `leiden EEC` labels appear in the lookup dictionary, resulting in only one entry for `EEC`. This conflict needs to be resolved to ensure proper functionality.

Solution:
Use `labelset:label` instead of just `label` as keys in parent_cell_look_up dictionary operations.