### PR TITLE
Add option to support filling empty slots with na during flattening for CAP

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,6 +35,9 @@ cas flatten --json path/to/json_file.json --anndata path/to/anndata_file.h5ad --
 - `--anndata`   : Path to the AnnData file. Ideally, the location will be specified by a resolvable path in the CAS file.
 - `--output`    : Optional output AnnData file name. If provided a new flatten anndata file will be created,
     otherwise the inputted anndata file will be updated with the flatten data.
+- `--fill-na`   : Optional boolean flag indicating whether to fill missing values in the 'obs' field with pd.NA. If 
+                    provided, missing values will be replaced with pd.NA; if not provided, they will remain as empty 
+  strings.
 
 Please check the [related notebook](../notebooks/test_flatten.ipynb) to evaluate the output data format.
 

--- a/src/cas/__main__.py
+++ b/src/cas/__main__.py
@@ -252,7 +252,6 @@ def create_flatten_operation_parser(subparsers):
         action="store_true",
         help="Boolean flag indicating whether to fill missing values in the 'obs' field with pd.NA. If provided, "
              "missing values will be replaced with pd.NA; if not provided, they will remain as empty strings.")
-    parser_flatten.set_defaults(validate=False)
 
 
 def create_unflatten_operation_parser(subparsers):

--- a/src/cas/__main__.py
+++ b/src/cas/__main__.py
@@ -55,12 +55,13 @@ def main():
         json_file_path = args.json
         anndata_file_path = args.anndata
         output_file_path = args.output
+        fill_na = args.fill_na
 
         if output_file_path and os.path.abspath(anndata_file_path) == os.path.abspath(
             output_file_path
         ):
             raise ValueError("--anndata and --output cannot be the same")
-        flatten(json_file_path, anndata_file_path, output_file_path)
+        flatten(json_file_path, anndata_file_path, output_file_path, fill_na)
     elif args.action == "unflatten":
         args = parser.parse_args()
         json_file_path = args.json
@@ -221,7 +222,9 @@ def create_flatten_operation_parser(subparsers):
     --json      : Path to the CAS JSON schema file.
     --anndata   : Path to the AnnData file. Ideally, the location will be specified by a resolvable path in the CAS file.
     --output    : Optional output AnnData file name. If provided a new flatten anndata file will be created,
-    otherwise the inputted anndata file will be updated with the flatten data.
+                    otherwise the inputted anndata file will be updated with the flatten data.
+    --fill-na   : Optional boolean flag indicating whether to fill missing values in the 'obs' field with pd.NA. If
+                    provided, missing values will be replaced with pd.NA; if not provided, they will remain as empty strings.
 
     Usage Example:
     --------------
@@ -243,6 +246,12 @@ def create_flatten_operation_parser(subparsers):
         required=False,
         help="Output AnnData file name.",
     )
+    parser_flatten.add_argument(
+        "--fill-na",
+        required=False,
+        action="store_true",
+        help="Boolean flag indicating whether to fill missing values in the 'obs' field with pd.NA. If provided, "
+             "missing values will be replaced with pd.NA; if not provided, they will remain as empty strings.")
     parser_flatten.set_defaults(validate=False)
 
 

--- a/src/test/cas_cap_roundtrip_test.py
+++ b/src/test/cas_cap_roundtrip_test.py
@@ -22,7 +22,7 @@ cas_file_path = "src/test/test_data/cas_cap_roundtrip/test_cas.json"
 class TestRoundtrip(unittest.TestCase):
     def test_roundtrip_without_edit(self):
         # Perform flattening and unflattening
-        flatten(cas_file_path, anndata_file_path, flattened_anndata_file_path)
+        flatten(cas_file_path, anndata_file_path, flattened_anndata_file_path, False)
         unflatten(
             json_file_path=None,
             anndata_file_path=flattened_anndata_file_path,
@@ -43,7 +43,7 @@ class TestRoundtrip(unittest.TestCase):
 
     def test_roundtrip_with_edit(self):
         # Perform flattening, update on flattened data and unflattening
-        flatten(cas_file_path, anndata_file_path, flattened_anndata_file_path)
+        flatten(cas_file_path, anndata_file_path, flattened_anndata_file_path, False)
         # Read the flattened Anndata object
         flattened_anndata = ad.read_h5ad(flattened_anndata_file_path, backed="r+")
         # rename a labelset cell label


### PR DESCRIPTION
Resolves #99 

Added `--fill-na` argument to the `flatten` CLI to allow users to fill missing values in the `AnnData.obs` field with `pd.NA` during the flattening process.