### PR TITLE
Fix for handling of missing cell_ids in upper hierarchy levels in split_anndata

### DIFF
--- a/src/cas/cas_splitter.py
+++ b/src/cas/cas_splitter.py
@@ -2,14 +2,14 @@ from collections import defaultdict
 from typing import Any, Dict, List, Union
 
 from cas.file_utils import read_json_file, write_dict_to_json_file
-
-ANNOTATIONS = "annotations"
-CELL_LABEL = "cell_label"
-CELL_SET_ACCESSION = "cell_set_accession"
-LABELSET = "labelset"
-LABELSETS = "labelsets"
-LABELSETS_NAME = "name"
-PARENT_CELL_SET_ACCESSION = "parent_cell_set_accession"
+from cas.utils.conversion_utils import (
+    ANNOTATIONS,
+    CELL_SET_ACCESSION,
+    LABELSET,
+    LABELSET_NAME,
+    LABELSETS,
+    PARENT_CELL_SET_ACCESSION,
+)
 
 
 def split_cas_to_file(
@@ -112,7 +112,7 @@ def filter_and_copy_cas_entries(
             output_dict[ANNOTATIONS].append(annotation)
             labelset_dict.add(annotation[LABELSET])
     for labelset in cas[LABELSETS]:
-        if labelset[LABELSETS_NAME] in labelset_dict:
+        if labelset[LABELSET_NAME] in labelset_dict:
             output_dict[LABELSETS].append(labelset)
     return output_dict
 

--- a/src/cas/utils/conversion_utils.py
+++ b/src/cas/utils/conversion_utils.py
@@ -268,24 +268,6 @@ def add_parent_hierarchy_to_annotations(
                 annotation.pop("cell_ontology_term", None)
 
 
-def json_serializer(obj):
-    """
-    JSON serializer for objects not serializable by default json code.
-    Usage: json.dumps(my_dict, default=json_serializer)
-
-    Args:
-        obj: object to serialize
-
-    Returns:
-        Serialized object.
-    """
-
-    if isinstance(obj, (datetime, date)):
-        # return obj.isoformat()
-        return obj.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
-    raise TypeError("Type %s not serializable" % type(obj))
-
-
 def get_authors_from_doi(doi):
     """
     Fetches and returns a list of authors from a given DOI (Digital Object Identifier) using the CrossRef API.

--- a/src/test/flatten_data_to_anndata_test.py
+++ b/src/test/flatten_data_to_anndata_test.py
@@ -9,16 +9,13 @@ from cas.flatten_data_to_anndata import (
     unflatten_obs,
     update_cas_json,
 )
-
-# Constants used in your module, assume these are defined somewhere in your code
-LABELSET_NAME = "name"
-LABELSETS = "labelsets"
-CELL_IDS = "cell_ids"
-AUTHOR_ANNOTATION_FIELDS = "author_annotation_fields"
-CELLHASH = "cellhash"
-CELL_LABEL = "cell_label"
-LABELSET = "labelset"
-ANNOTATIONS = "annotations"
+from cas.utils.conversion_utils import (
+    ANNOTATIONS,
+    AUTHOR_ANNOTATION_FIELDS,
+    CELL_IDS,
+    CELL_LABEL,
+    CELLHASH,
+)
 
 
 class TestAnnotationMethods(unittest.TestCase):


### PR DESCRIPTION
Fixes #126 

Additionally, I have refactored the merge and flatten scripts to remove duplicate functionality, consolidating it into conversion_utils.py. Also, I performed some general cleanup across the codebase.