### PR TITLE
Added cas obj null check for linkml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cas-tools"
-version = "1.0.11"
+version = "1.0.12"
 description = "Cell Annotation Schema tools."
 authors = ["Huseyin Kir <hk9@sanger.ac.uk>", "Ugur Bayindir <ub2@sanger.ac.uk>"]
 license = "Apache-2.0 license"

--- a/src/cas/flatten_data_to_anndata.py
+++ b/src/cas/flatten_data_to_anndata.py
@@ -200,23 +200,23 @@ def generate_uns_json(input_json):
 
     for key in root_keys:
         value = input_json[key]
-    if not value:
-        continue
-
-    if is_list_of_strings(value):
-        uns_json[key] = ", ".join(sorted(value))
-    elif isinstance(value, str):
-        uns_json[key] = value
-    else:
-        metadata_json = {}
-        for labelset in value:
-            metadata_key = labelset.get(LABELSET_NAME, "")
-            metadata_json.update({metadata_key: {}})
-            for k, v in labelset.items():
-                if k == LABELSET_NAME:
-                    continue
-                metadata_json.get(metadata_key, {}).update({k: v})
-        uns_json["cellannotation_metadata"] = metadata_json
+        if not value:
+            continue
+    
+        if is_list_of_strings(value):
+            uns_json[key] = ", ".join(sorted(value))
+        elif isinstance(value, str):
+            uns_json[key] = value
+        else:
+            metadata_json = {}
+            for labelset in value:
+                metadata_key = labelset.get(LABELSET_NAME, "")
+                metadata_json.update({metadata_key: {}})
+                for k, v in labelset.items():
+                    if k == LABELSET_NAME:
+                        continue
+                    metadata_json.get(metadata_key, {}).update({k: v})
+            uns_json["cellannotation_metadata"] = metadata_json
 
     uns_json["cas"] = reformat_json(input_json)
 

--- a/src/cas/flatten_data_to_anndata.py
+++ b/src/cas/flatten_data_to_anndata.py
@@ -131,9 +131,9 @@ def process_annotations(annotations, obs_index, parent_cell_ids, fill_na):
     accession_manager = HashAccessionManager()
     flatten_data = {}
     for ann in annotations:
-        cell_ids = ann.get(
-            CELL_IDS, parent_cell_ids.get(ann.get("cell_set_accession", []))
-        )
+        cell_ids = ann.get(CELL_IDS, [])
+        if not cell_ids:
+            cell_ids = parent_cell_ids.get(ann.get("cell_set_accession", []))
 
         ann.get("%s" % AUTHOR_ANNOTATION_FIELDS, {}).update(
             {
@@ -200,20 +200,21 @@ def generate_uns_json(input_json):
 
     for key in root_keys:
         value = input_json[key]
-        if is_list_of_strings(value):
-            uns_json[key] = ", ".join(sorted(value))
-        elif isinstance(value, str):
-            uns_json[key] = value
-        else:
-            metadata_json = {}
-            for labelset in value:
-                metadata_key = labelset.get(LABELSET_NAME, "")
-                metadata_json.update({metadata_key: {}})
-                for k, v in labelset.items():
-                    if k == LABELSET_NAME:
-                        continue
-                    metadata_json.get(metadata_key, {}).update({k: v})
-            uns_json["cellannotation_metadata"] = metadata_json
+        if value:
+            if is_list_of_strings(value):
+                uns_json[key] = ", ".join(sorted(value))
+            elif isinstance(value, str):
+                uns_json[key] = value
+            else:
+                metadata_json = {}
+                for labelset in value:
+                    metadata_key = labelset.get(LABELSET_NAME, "")
+                    metadata_json.update({metadata_key: {}})
+                    for k, v in labelset.items():
+                        if k == LABELSET_NAME:
+                            continue
+                        metadata_json.get(metadata_key, {}).update({k: v})
+                uns_json["cellannotation_metadata"] = metadata_json
 
     uns_json["cas"] = reformat_json(input_json)
 

--- a/src/cas/flatten_data_to_anndata.py
+++ b/src/cas/flatten_data_to_anndata.py
@@ -200,21 +200,23 @@ def generate_uns_json(input_json):
 
     for key in root_keys:
         value = input_json[key]
-        if value:
-            if is_list_of_strings(value):
-                uns_json[key] = ", ".join(sorted(value))
-            elif isinstance(value, str):
-                uns_json[key] = value
-            else:
-                metadata_json = {}
-                for labelset in value:
-                    metadata_key = labelset.get(LABELSET_NAME, "")
-                    metadata_json.update({metadata_key: {}})
-                    for k, v in labelset.items():
-                        if k == LABELSET_NAME:
-                            continue
-                        metadata_json.get(metadata_key, {}).update({k: v})
-                uns_json["cellannotation_metadata"] = metadata_json
+    if not value:
+        continue
+
+    if is_list_of_strings(value):
+        uns_json[key] = ", ".join(sorted(value))
+    elif isinstance(value, str):
+        uns_json[key] = value
+    else:
+        metadata_json = {}
+        for labelset in value:
+            metadata_key = labelset.get(LABELSET_NAME, "")
+            metadata_json.update({metadata_key: {}})
+            for k, v in labelset.items():
+                if k == LABELSET_NAME:
+                    continue
+                metadata_json.get(metadata_key, {}).update({k: v})
+        uns_json["cellannotation_metadata"] = metadata_json
 
     uns_json["cas"] = reformat_json(input_json)
 


### PR DESCRIPTION
Till now we weren't adding fields whose value is null to the CAS object. However now we are planning to use linkML generated python objects/dicts/json_files for this purpose. This fix adds checks for given scenarios we came across in preliminary experiments:

- Previously parent cellists (non-clusters) didn't have a `cell_ids` property. Now they have `"cells": {}` as value
- there are metadata with null values such as `"cellannotation_timestamp": null`