### PR TITLE
Extend support for labelsets without ranks

### DIFF
--- a/src/cas/__main__.py
+++ b/src/cas/__main__.py
@@ -778,8 +778,10 @@ def create_split_anndata_parser(subparsers):
     cd src
     python -m cas split_anndata --cas_json path/to/cas.json
     python -m cas split_anndata --anndata path/to/anndata.h5ad --cas_json path/to/cas.json
-    python -m cas split_anndata --anndata path/to/anndata.h5ad path/to/cas_1.json path/to/cas_2.json --compression lzf
-    python -m cas split_anndata --anndata path/to/anndata.h5ad path/to/cas_1.json path/to/cas_2.json
+    python -m cas split_anndata --anndata path/to/anndata.h5ad --cas_json path/to/cas_1.json
+    path/to/cas_2.json --compression lzf
+    python -m cas split_anndata --anndata path/to/anndata.h5ad --cas_json path/to/cas_1.json
+    path/to/cas_2.json
     --multiple_outputs --compression
     """
     parser_split_anndata = subparsers.add_parser(

--- a/src/cas/utils/conversion_utils.py
+++ b/src/cas/utils/conversion_utils.py
@@ -174,7 +174,9 @@ def collect_parent_cell_ids(cas: Dict[str, Any]) -> Dict[str, Set]:
     """
     parent_cell_ids = dict()
 
-    labelsets = sorted(cas[LABELSETS], key=lambda x: int(x["rank"]))
+    labelsets = sorted(
+        [ls for ls in cas[LABELSETS] if "rank" in ls], key=lambda x: int(x["rank"])
+    )
     for labelset in labelsets:
         ls_annotations = [
             ann for ann in cas[ANNOTATIONS] if ann[LABELSET] == labelset[LABELSET_NAME]

--- a/src/test/validation_utils_test.py
+++ b/src/test/validation_utils_test.py
@@ -4,12 +4,12 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 
 from cas.utils.validation_utils import (
-    validate_labelset_markers,
-    validate_markers,
     compare_labelsets_cas_obs,
-    validate_labelset_values,
     infer_cas_cell_hierarchy,
     infer_obs_cell_hierarchy,
+    validate_labelset_markers,
+    validate_labelset_values,
+    validate_markers,
 )
 
 
@@ -78,7 +78,7 @@ class TestMarkerValidation(unittest.TestCase):
     def test_compare_labelsets_cas_obs(self):
         obs = pd.DataFrame({"set1": ["A", "B"], "set2": ["X", "Y"]})
 
-        cas = {"labelsets": [{"name": "set1"}, {"name": "set2"}]}
+        cas = {"labelsets": [{"name": "set1", "rank": 0}, {"name": "set2", "rank": 1}]}
 
         # All labelsets exist in obs (should return True)
         result = compare_labelsets_cas_obs(cas, obs)
@@ -113,7 +113,12 @@ class TestMarkerValidation(unittest.TestCase):
                 {"labelset": "set2", "cell_label": "X"},
                 {"labelset": "set2", "cell_label": "Y"},
                 {"labelset": "set2", "cell_label": "Z"},
-            ]
+            ],
+            "labelsets": [
+                {"name": "set1", "rank": 0},
+                {"name": "set2", "rank": 1},
+                {"name": "set3"},
+            ],
         }
 
         # All labelset members exist (should return True)
@@ -133,7 +138,14 @@ class TestMarkerValidation(unittest.TestCase):
         self.assertFalse(validate_labelset_values(cas, missing_labelset_obs))
 
         # Empty CAS annotations (should return True)
-        empty_cas = {"annotations": []}
+        empty_cas = {
+            "annotations": [],
+            "labelsets": [
+                {"name": "set1", "rank": 0},
+                {"name": "set2", "rank": 1},
+                {"name": "set3"},
+            ],
+        }
         self.assertTrue(validate_labelset_values(empty_cas, obs))
 
         # Empty obs DataFrame (should return False)


### PR DESCRIPTION
This PR addresses an issue in the hierarchical validation within the `populate_cell_ids` method. Previously, the validation assumed that all labelsets in the CAS contained rank information, which isn't always the case. This update extends support for labelsets without ranks by gracefully handling missing rank values to prevent failures and ensure accurate parent-child relationships.

Fixes #151.

Key changes:
- Updated validation logic in `populate_cell_ids` and related modules to correctly process labelsets that lack rank.
- Ensured that missing rank information doesn't cause errors during the hierarchy validation process.
- Builds on previous support introduced in #155.