### PR TITLE
neurotransmitter_accession handling added on table flattening

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cas-tools"
-version = "1.1.5"
+version = "1.1.6"
 description = "Cell Annotation Schema tools."
 authors = ["Huseyin Kir <hk9@sanger.ac.uk>", "Ugur Bayindir <ub2@sanger.ac.uk>"]
 license = "Apache-2.0 license"

--- a/src/cas/flatten_data_to_anndata.py
+++ b/src/cas/flatten_data_to_anndata.py
@@ -378,10 +378,11 @@ def unflatten_obs(
         )
     ]
     # Handle rankless labelsets
-    rankless_labelsets = [
-        labelset for labelset in cas_json[LABELSETS] if "rank" not in labelset
-    ]
-    updated_cas[LABELSETS].extend(rankless_labelsets)
+    if cas_json:
+        rankless_labelsets = [
+            labelset for labelset in cas_json[LABELSETS] if "rank" not in labelset
+        ]
+        updated_cas[LABELSETS].extend(rankless_labelsets)
     # Discard flattened obs
     flattened_columns = [
         col

--- a/src/cas/flatten_data_to_tables.py
+++ b/src/cas/flatten_data_to_tables.py
@@ -234,6 +234,13 @@ def generate_annotation_table(accession_prefix, cta, out_folder):
                 annotation_object.get("marker_gene_evidence", [])
             )
             record["synonyms"] = list_to_string(annotation_object.get("synonyms", []))
+            record["neurotransmitter_accession"] = annotation_object.get(
+                "neurotransmitter_accession", "")
+            record["neurotransmitter_rationale"] = annotation_object.get(
+                "neurotransmitter_rationale", "")
+            record["neurotransmitter_marker_gene_evidence"] = list_to_string(
+                annotation_object.get("neurotransmitter_marker_gene_evidence", [])
+            )
             if annotation_object.get("author_annotation_fields"):
                 for key, value in annotation_object["author_annotation_fields"].items():
                     if normalize_column_name(key) in record:

--- a/src/cas/model.py
+++ b/src/cas/model.py
@@ -173,6 +173,15 @@ class Annotation(EncoderMixin):
     """"A dictionary of author defined key value pairs annotating the cell set. The names and aims of these fields MUST 
     not clash with official annotation fields."""
 
+    neurotransmitter_accession: Optional[str] = None
+    """Accessions of cell neurotransmitter associated with this cell set."""
+
+    neurotransmitter_rationale: Optional[str] = None
+    """The free-text rationale which users provide as justification/evidence for supporting the neurotransmitter association."""
+
+    neurotransmitter_marker_gene_evidence: Optional[List[str]] = None
+    """List of gene names used as evidence for neurotransmitter association. Each gene MUST be included in the matrix of the AnnData/Seurat file."""
+
     transferred_annotations: Optional[List[AnnotationTransfer]] = None
 
     reviews: Optional[List[Review]] = None

--- a/src/test/conversion_utils_test.py
+++ b/src/test/conversion_utils_test.py
@@ -1,6 +1,6 @@
 import unittest
 import warnings
-from test.spreadsheet_to_cas_test import generate_mock_dataset
+from src.test.spreadsheet_to_cas_test import generate_mock_dataset
 
 import pandas as pd
 

--- a/src/test/reports_test.py
+++ b/src/test/reports_test.py
@@ -23,17 +23,17 @@ class ReportsTests(unittest.TestCase):
 
         df = cas.get_all_annotations()
         self.assertEqual(89, df.shape[0])
-        self.assertEqual(15, df.shape[1])
+        self.assertEqual(18, df.shape[1])
 
         cas = asdict(cas)
         df = get_all_annotations(cas)
         # print(df)
         self.assertEqual(89, df.shape[0])
-        self.assertEqual(15, df.shape[1])
+        self.assertEqual(18, df.shape[1])
 
         df = get_all_annotations(cas, show_cell_ids=True)
         self.assertEqual(89, df.shape[0])
-        self.assertEqual(16, df.shape[1])
+        self.assertEqual(19, df.shape[1])
 
     def test_annotations_listing_with_pairs(self):
         cas = read_cas_json_file(TEST_JSON)
@@ -49,7 +49,7 @@ class ReportsTests(unittest.TestCase):
         )
         print(df)
         self.assertEqual(3, df.shape[0])
-        self.assertEqual(15, df.shape[1])
+        self.assertEqual(18, df.shape[1])
 
     def test_cell_ids_not_existing(self):
         cas = read_cas_json_file(TEST_JSON)
@@ -61,4 +61,4 @@ class ReportsTests(unittest.TestCase):
         df = get_all_annotations(cas)
         # print(df)
         self.assertEqual(89, df.shape[0])
-        self.assertEqual(15, df.shape[1])
+        self.assertEqual(18, df.shape[1])


### PR DESCRIPTION
neurotransmitter_accession, neurotransmitter_rationale and neurotransmitter_marker_gene_evidence fields handling added to the cas_2_table flattening
